### PR TITLE
Fix blank page issue by echoing JS alert and redirect in jsAlertRedirect()

### DIFF
--- a/app/controllers/add_machine.php
+++ b/app/controllers/add_machine.php
@@ -4,6 +4,9 @@
     It retrieves form data, sanitizes it, and inserts it into the database.
 */
 
+ini_set("log_errors", 1);
+error_reporting(E_ALL);
+
 // Start session and check if user is logged in
 session_start(); 
 if (!isset($_SESSION['user_id'])) {
@@ -40,6 +43,7 @@ if (empty($control_no) || empty($description) || empty($model) || empty($machine
 if ($description !== 'AUTOMATIC' && $description !== 'SEMI-AUTOMATIC') {
     jsAlertRedirect("Invalid selection for description.", "../views/add_entry.php");
     exit;
+}
 
 // 3. Database operation
 $result = createMachine($control_no, $description, $model,

--- a/app/includes/header.php
+++ b/app/includes/header.php
@@ -12,8 +12,7 @@
             <span>HEPC</span>
         </div>
         <nav class="nav">
-            <a href="../templates/login.php" class="nav-link">LOG IN  ||  </a>
-            <a href="../templates/signin.php" class="nav-link">SIGN UP</a>
-
+            <a href="../views/login.php" class="nav-link">LOG IN  ||  </a>
+            <a href="../views/signup.php" class="nav-link">SIGN UP</a>
         </nav>
     </div>

--- a/app/includes/js_alert.php
+++ b/app/includes/js_alert.php
@@ -11,5 +11,5 @@ function jsAlertRedirect($message, $redirect_url="../views/login.php") {
     - $message (string): The message to display in the alert.
     - $redirect_url (string): The URL to redirect to after the alert.
     */
-    return "<script>alert('$message'); window.location.href = '$redirect_url';</script>";
+    echo "<script>alert('$message'); window.location.href = '$redirect_url';</script>";
 }


### PR DESCRIPTION
### Summary
Fixed a bug where `jsAlertRedirect()` was returning a JavaScript alert instead of echoing it, causing a blank page on form submission. This change ensures that the alert message is properly rendered in the browser and followed by a redirect.

### Changes
- Updated `jsAlertRedirect()` to use `echo` instead of `return`
- Minor improvement: added missing closing curly brackets in app/controllers/add_machine.php
- Minor improvement: fixed hrefs in app/includes/header.php