### PR TITLE
Implement cumulative monitoring for outputs including standard and custom parts

### DIFF
--- a/app/controllers/record_output.php
+++ b/app/controllers/record_output.php
@@ -112,5 +112,29 @@ if (is_string($machine_status)) {
     exit;
 }
 
+// Upodate monitoring tables
+require_once '../models/update_monitor_applicator.php';
+$app1_monitor_status = monitorApplicatorOutput($app1_data, $app1_out);
+if (is_string($app1_monitor_status)) {
+    jsAlertRedirect($app1_monitor_status, $redirect);
+    exit;
+}
+
+$app2_monitor_status = null;
+if ($app2_data) {
+    $app2_monitor_status = monitorApplicatorOutput($app2_data, $app2_out);
+    if (is_string($app2_monitor_status)) {
+        jsAlertRedirect($app2_monitor_status, $redirect);
+        exit;
+    }
+}
+
+require_once '../models/update_monitor_machine.php';
+$machine_monitor_status = monitorMachineOutput($machine_data, $machine_out);
+if (is_string($machine_monitor_status)) {
+    jsAlertRedirect($machine_monitor_status, $redirect);
+    exit;
+}
+
 // If all operations were successful, redirect to the record output page with success message
 jsAlertRedirect("All outputs recorded successfully!", $redirect);

--- a/app/models/create_applicator.php
+++ b/app/models/create_applicator.php
@@ -8,8 +8,8 @@
 require_once __DIR__ . '/../includes/db.php';
 
 function createApplicator($control_no, $terminal_no, $description, 
-                           $wire_type, $terminal_maker, $applicator_maker, 
-                           $serial_no, $invoice_no) {
+                        $wire_type, $terminal_maker, $applicator_maker, 
+                        $serial_no, $invoice_no) {
     /*
     Function to create a new applicator in the database.
     
@@ -38,7 +38,7 @@ function createApplicator($control_no, $terminal_no, $description,
         // Prepare SQL insert query
         $stmt = $pdo->prepare("
             INSERT INTO applicators (hp_no, terminal_no, description, wire, 
-                                     terminal_maker, applicator_maker, serial_no, invoice_no)
+                                    terminal_maker, applicator_maker, serial_no, invoice_no)
             VALUES (:control_no, :terminal_no, :description, :wire_type, 
                     :terminal_maker, :applicator_maker, :serial_no, :invoice_no)
         ");

--- a/app/models/create_applicator_output.php
+++ b/app/models/create_applicator_output.php
@@ -61,10 +61,10 @@ function submitApplicatorOutput($applicator_data, $applicator_output, $record_id
                 $stmt = $pdo->prepare("
                     INSERT INTO applicator_outputs 
                     (record_id, applicator_id, total_output, wire_crimper, wire_anvil, 
-                     insulation_crimper, insulation_anvil, slide_cutter, cutter_holder, custom_parts) 
+                    insulation_crimper, insulation_anvil, slide_cutter, cutter_holder, custom_parts) 
                     VALUES 
                     (:record_id, :applicator_id, :output_value, :output_value, :output_value, 
-                     :output_value, :output_value, :output_value, :output_value, :custom_parts)
+                    :output_value, :output_value, :output_value, :output_value, :custom_parts)
                 ");
                 break;
                 
@@ -72,10 +72,10 @@ function submitApplicatorOutput($applicator_data, $applicator_output, $record_id
                 $stmt = $pdo->prepare("
                     INSERT INTO applicator_outputs 
                     (record_id, applicator_id, total_output, wire_crimper, wire_anvil, 
-                     insulation_crimper, insulation_anvil, shear_blade, cutter_a, cutter_b, custom_parts) 
+                    insulation_crimper, insulation_anvil, shear_blade, cutter_a, cutter_b, custom_parts) 
                     VALUES 
                     (:record_id, :applicator_id, :output_value, :output_value, :output_value, 
-                     :output_value, :output_value, :output_value, :output_value, :output_value, :custom_parts)
+                    :output_value, :output_value, :output_value, :output_value, :output_value, :custom_parts)
                 ");
                 break;
                 

--- a/app/models/create_machine.php
+++ b/app/models/create_machine.php
@@ -8,7 +8,7 @@
 require_once __DIR__ . '/../includes/db.php';
 
 function createMachine($control_no, $description, $model,
-                          $machine_maker, $serial_no, $invoice_no) {
+                        $machine_maker, $serial_no, $invoice_no) {
     /*
     Function to create a new machine in the database.
     
@@ -35,7 +35,7 @@ function createMachine($control_no, $description, $model,
         // Prepare SQL insert query
         $stmt = $pdo->prepare("
             INSERT INTO machines (control_no, description, model, 
-                                     maker, serial_no, invoice_no)
+                                    maker, serial_no, invoice_no)
             VALUES (:control_no, :description, :model,
                     :machine_maker, :serial_no, :invoice_no)
         ");

--- a/app/models/create_machine_output.php
+++ b/app/models/create_machine_output.php
@@ -32,7 +32,7 @@ function submitMachineOutput($machine_data, $machine_output, $record_id) {
         require_once __DIR__ . '/read_custom_parts.php';
         $custom_machine_parts = getCustomParts('MACHINE');
 
-       if (is_string($custom_machine_parts)) {
+        if (is_string($custom_machine_parts)) {
             // If getCustomParts returned an error 
             return $custom_machine_parts;
         }

--- a/app/models/read_applicators.php
+++ b/app/models/read_applicators.php
@@ -25,9 +25,9 @@ function getApplicators(PDO $pdo, int $limit = 10, int $offset = 0): array {
 
 
     $stmt = $pdo->prepare("SELECT hp_no, terminal_no, description, wire, terminal_maker, applicator_maker, serial_no, invoice_no
-                           FROM applicators
-                           ORDER BY applicator_id DESC
-                           LIMIT :limit OFFSET :offset");
+                        FROM applicators
+                        ORDER BY applicator_id DESC
+                        LIMIT :limit OFFSET :offset");
 
     $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
     $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);

--- a/app/models/read_user.php
+++ b/app/models/read_user.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/../includes/db.php';
 function loginUser($username, $password) {
     /*
     Function to log in a user by checking the username and password.
-  
+
     Args:
     - $username: The username of the user.
     - $password: The password of the user.

--- a/app/models/update_monitor_applicator.php
+++ b/app/models/update_monitor_applicator.php
@@ -1,0 +1,127 @@
+<?php
+/*
+    This script handles both the CREATE and UPDATE operation for recording the cumulative sum of applicator outputs.
+    It updates standard part counters and increments JSON values for custom parts.
+*/
+
+require_once __DIR__ . '/../includes/db.php';
+
+function monitorApplicatorOutput($applicator_data, $applicator_output) {
+    /*
+    Function to monitor cumulative outputs of each applicator and its components.
+
+    Args:
+    - $applicator_data: The data of the applicator.
+    - $applicator_output: The output value of the applicator.
+
+    Returns:
+    - True if the monitoring is successful.
+    - String containing error message and redirect using JS <alert>.
+    */
+
+    global $pdo;
+
+    try {
+        $type = $applicator_data['description'];
+        $applicator_id = $applicator_data['applicator_id'];
+
+        // Fetch applicable custom parts
+        require_once __DIR__ . '/read_custom_parts.php';
+        $custom_parts = getCustomParts('APPLICATOR');
+
+        if (is_string($custom_parts)) {
+            return $custom_parts; // Error from getCustomParts
+        }
+
+        // Build new parts to add (e.g., {"partA": 50, "partB": 50})
+        $new_parts = [];
+        foreach ($custom_parts as $part) {
+            $new_parts[$part['part_name']] = $applicator_output;
+        }
+
+        // Fetch existing JSON (if any)
+        $stmt_check = $pdo->prepare("SELECT custom_parts_output FROM monitor_applicator WHERE applicator_id = :id LIMIT 1");
+        $stmt_check->execute([':id' => $applicator_id]);
+        $existing = $stmt_check->fetchColumn();
+
+        if ($existing) {
+            $existing_parts = json_decode($existing, true) ?? [];
+            // Merge and increment values
+            foreach ($new_parts as $key => $val) {
+                if (isset($existing_parts[$key])) {
+                    $existing_parts[$key] += $val;
+                } else {
+                    $existing_parts[$key] = $val;
+                }
+            }
+            $custom_parts_json = json_encode($existing_parts);
+        } else {
+            $custom_parts_json = json_encode($new_parts);
+        }
+
+        // Determine query based on type
+        switch ($type) {
+            case "SIDE":
+                $stmt = $pdo->prepare("
+                    INSERT INTO monitor_applicator (
+                        applicator_id, total_output, wire_crimper_output, wire_anvil_output, 
+                        insulation_crimper_output, insulation_anvil_output, slide_cutter_output, 
+                        cutter_holder_output, custom_parts_output, last_updated
+                    ) VALUES (
+                        :applicator_id, :val, :val, :val,
+                        :val, :val, :val,
+                        :val, :custom_json, CURRENT_TIMESTAMP
+                    )
+                    ON DUPLICATE KEY UPDATE
+                        total_output = total_output + :val,
+                        wire_crimper_output = wire_crimper_output + :val,
+                        wire_anvil_output = wire_anvil_output + :val,
+                        insulation_crimper_output = insulation_crimper_output + :val,
+                        insulation_anvil_output = insulation_anvil_output + :val,
+                        slide_cutter_output = slide_cutter_output + :val,
+                        cutter_holder_output = cutter_holder_output + :val,
+                        custom_parts_output = :custom_json,
+                        last_updated = CURRENT_TIMESTAMP
+                ");
+                break;
+
+            case "END":
+                $stmt = $pdo->prepare("
+                    INSERT INTO monitor_applicator (
+                        applicator_id, total_output, wire_crimper_output, wire_anvil_output, 
+                        insulation_crimper_output, insulation_anvil_output, shear_blade_output, 
+                        cutter_a_output, cutter_b_output, custom_parts_output, last_updated
+                    ) VALUES (
+                        :applicator_id, :val, :val, :val,
+                        :val, :val, :val, :val,
+                        :val, :custom_json, CURRENT_TIMESTAMP
+                    )
+                    ON DUPLICATE KEY UPDATE
+                        total_output = total_output + :val,
+                        wire_crimper_output = wire_crimper_output + :val,
+                        wire_anvil_output = wire_anvil_output + :val,
+                        insulation_crimper_output = insulation_crimper_output + :val,
+                        cutter_a_output = cutter_a_output + :val,
+                        cutter_b_output = cutter_b_output + :val,
+                        custom_parts_output = :custom_json,
+                        last_updated = CURRENT_TIMESTAMP
+                ");
+                break;
+
+            default:
+                return "Invalid applicator type: " . htmlspecialchars($type, ENT_QUOTES);
+        }
+
+        // Bind parameters
+        $stmt->bindParam(':applicator_id', $applicator_id, PDO::PARAM_INT);
+        $stmt->bindParam(':val', $applicator_output, PDO::PARAM_INT);
+        $stmt->bindParam(':custom_json', $custom_parts_json, PDO::PARAM_STR);
+
+        $stmt->execute();
+        return true;
+
+    } catch (PDOException $e) {
+        error_log("DB Error in monitorApplicatorOutput(): " . $e->getMessage());
+        return "Database error: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/models/update_monitor_machine.php
+++ b/app/models/update_monitor_machine.php
@@ -1,0 +1,90 @@
+<?php
+/*
+    This script handles both the CREATE and UPDATE operation for recording the cumulative sum of machine outputs.
+    It updates standard part counters and increments JSON values for custom parts.
+*/
+
+require_once __DIR__ . '/../includes/db.php';
+
+function monitorMachineOutput($machine_data, $machine_output) {
+    /*
+    Function to monitor cumulative outputs of each machine and its components.
+
+    Args:
+    - $machine_data: The data of the machine.
+    - $machine_output: The output value of the machine.
+
+    Returns:
+    - True if the monitoring is successful.
+    - String containing error message and redirect using JS <alert>.
+    */
+
+    global $pdo;
+
+    try {
+        $machine_id = $machine_data['machine_id'];
+
+        // Fetch applicable custom parts
+        require_once __DIR__ . '/read_custom_parts.php';
+        $custom_parts = getCustomParts('MACHINE');
+
+        if (is_string($custom_parts)) {
+            return $custom_parts; // Error from getCustomParts
+        }
+
+        // Build new parts to add (e.g., {"partA": 50, "partB": 50})
+        $new_parts = [];
+        foreach ($custom_parts as $part) {
+            $new_parts[$part['part_name']] = $machine_output;
+        }
+
+        // Fetch existing JSON (if any)
+        $stmt_check = $pdo->prepare("SELECT custom_parts_output FROM monitor_machine WHERE machine_id = :id LIMIT 1");
+        $stmt_check->execute([':id' => $machine_id]);
+        $existing = $stmt_check->fetchColumn();
+
+        if ($existing) {
+            $existing_parts = json_decode($existing, true) ?? [];
+            // Merge and increment values
+            foreach ($new_parts as $key => $val) {
+                if (isset($existing_parts[$key])) {
+                    $existing_parts[$key] += $val;
+                } else {
+                    $existing_parts[$key] = $val;
+                }
+            }
+            $custom_parts_json = json_encode($existing_parts);
+        } else {
+            $custom_parts_json = json_encode($new_parts);
+        }
+
+        $stmt = $pdo->prepare("
+                    INSERT INTO monitor_machine (
+                        machine_id, total_machine_output, cut_blade_output, strip_blade_a_output, 
+                        strip_blade_b_output, custom_parts_output, last_updated
+                    ) VALUES (
+                        :machine_id, :val, :val, :val,
+                        :val, :custom_json, CURRENT_TIMESTAMP
+                    )
+                    ON DUPLICATE KEY UPDATE
+                        total_machine_output = total_machine_output + :val,
+                        cut_blade_output = cut_blade_output + :val,
+                        strip_blade_a_output = strip_blade_a_output + :val,
+                        strip_blade_b_output = strip_blade_b_output + :val,
+                        custom_parts_output = :custom_json,
+                        last_updated = CURRENT_TIMESTAMP
+                ");
+
+        // Bind parameters
+        $stmt->bindParam(':machine_id', $machine_id, PDO::PARAM_INT);
+        $stmt->bindParam(':val', $machine_output, PDO::PARAM_INT);
+        $stmt->bindParam(':custom_json', $custom_parts_json, PDO::PARAM_STR);
+
+        $stmt->execute();   
+        return true;
+
+    } catch (PDOException $e) {
+        error_log("DB Error in monitorMachineOutput(): " . $e->getMessage());
+        return "Database error: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/sql/updated_schema.sql
+++ b/app/sql/updated_schema.sql
@@ -150,7 +150,7 @@ CREATE TABLE machine_outputs (
 -- Hybrid monitor tables
 CREATE TABLE monitor_machine (
     monitor_id INT PRIMARY KEY AUTO_INCREMENT,
-    machine_id INT NOT NULL,
+    machine_id INT NOT NULL UNIQUE,
     
     -- Standard parts totals
     total_machine_output INT DEFAULT 0,
@@ -171,7 +171,7 @@ CREATE TABLE monitor_machine (
 
 CREATE TABLE monitor_applicator (
     monitor_id INT PRIMARY KEY AUTO_INCREMENT,
-    applicator_id INT NOT NULL,
+    applicator_id INT NOT NULL UNIQUE,
 
     -- Standard parts totals
     total_output INT DEFAULT 0,

--- a/app/sql/updated_schema_documentation.md
+++ b/app/sql/updated_schema_documentation.md
@@ -172,7 +172,7 @@ This database system is designed to track machine and applicator usage in a manu
 | Column | Type | Constraints | Description |
 |--------|------|-------------|-------------|
 | `monitor_id` | INT | PRIMARY KEY, AUTO_INCREMENT | Unique identifier |
-| `machine_id` | INT | NOT NULL, FK → machines | Machine being monitored |
+| `machine_id` | INT | NOT NULL, UNIQUE, FK → machines | Machine being monitored |
 | **Standard Parts Totals** | | | |
 | `total_machine_output` | INT | DEFAULT 0 | Cumulative total output |
 | `cut_blade_output` | INT | DEFAULT 0 | Cumulative cut blade output |
@@ -190,7 +190,7 @@ This database system is designed to track machine and applicator usage in a manu
 | Column | Type | Constraints | Description |
 |--------|------|-------------|-------------|
 | `monitor_id` | INT | PRIMARY KEY, AUTO_INCREMENT | Unique identifier |
-| `applicator_id` | INT | NOT NULL, FK → applicators | Applicator being monitored |
+| `applicator_id` | INT | NOT NULL, UNIQUE, FK → applicators | Applicator being monitored |
 | **Standard Parts Totals** | | | |
 | `total_output` | INT | DEFAULT 0 | Cumulative total output |
 | `wire_crimper_output` | INT | DEFAULT 0 | Cumulative wire crimper output |


### PR DESCRIPTION
## Summary
Implements backend logic for tracking cumulative outputs across all submissions. The system records and updates both standard and custom part totals per applicator and machine.

## Changes
- Adds or updates entries based on `applicator_id`/`machine_id` using `ON DUPLICATE KEY UPDATE`.
- Dynamically encodes custom part output values into JSON format and merges the previous and new values.
- Updates standard part output columns in bulk with a single parameter (`:val`) based on applicator type.
- Ensures consistent timestamp updates via `CURRENT_TIMESTAMP`.
- Uses a structured switch-case block to support SIDE and END applicator types separately.

## Technical Notes
- `applicator_id` and `machine_id` are now treated as unique keys in monitoring tables to trigger updates when inserting duplicates.
- Merged JSON values intelligently (not overwritten), supporting incremental custom part counts.
