### PR TITLE
fix: remove id column in machines table ui

### DIFF
--- a/app/views/add_entry.php
+++ b/app/views/add_entry.php
@@ -78,7 +78,6 @@ include_once __DIR__ . '/../includes/header.php'; // Include the header file for
                     <thead>
                         <!-- Table headers defining machine data columns -->
                         <tr>
-                            <th>ID</th>
                             <th>Control No</th>
                             <th>Description</th>
                             <th>Model</th>
@@ -102,7 +101,6 @@ include_once __DIR__ . '/../includes/header.php'; // Include the header file for
                         <!-- Render fetched machine data as table rows -->
                         <?php foreach ($machines as $row): ?>
                             <tr>
-                                <td><?= htmlspecialchars($row['machine_id']) ?></td>
                                 <td><?= htmlspecialchars($row['control_no']) ?></td>
                                 <td><?= htmlspecialchars($row['description']) ?></td>
                                 <td><?= htmlspecialchars($row['model']) ?></td>

--- a/public/assets/js/load_machines.js
+++ b/public/assets/js/load_machines.js
@@ -22,10 +22,6 @@ function loadMachines() {
         data.forEach(row => {
             const tr = document.createElement('tr');
 
-            const tdId = document.createElement('td');
-            tdId.textContent = row.machine_id;
-            tr.appendChild(tdId);
-
             const tdControlNo = document.createElement('td');
             tdControlNo.textContent = row.control_no;
             tr.appendChild(tdControlNo);


### PR DESCRIPTION
### Summary
refactor(machines table): remove visible ID column, preserve machine_id for backend actions
