### PR TITLE
feat: add frontend modal for machine editing (UI only, backend pending)

### DIFF
--- a/app/views/add_entry.php
+++ b/app/views/add_entry.php
@@ -25,6 +25,8 @@ include_once __DIR__ . '/../includes/header.php'; // Include the header file for
     <script src="../../public/assets/js/load_machines.js" defer></script>
     <!-- Load applicator infinite scroll logic -->
     <script src="../../public/assets/js/load_applicators.js" defer></script>
+    <!-- Load modal logic for editing machines -->
+    <script src="../../public/assets/js/edit_machine_modal.js" defer></script>
 </head>
     <body>
 
@@ -108,8 +110,19 @@ include_once __DIR__ . '/../includes/header.php'; // Include the header file for
                                 <td><?= htmlspecialchars($row['serial_no']) ?></td>
                                 <td><?= htmlspecialchars($row['invoice_no']) ?></td>
                                 <td>
-                                    <!-- Edit link -->
-                                    <a href="../controllers/edit_machine.php?id=<?= $row['machine_id'] ?>">✏️</a>
+
+                                <!-- Edit link with data attributes -->
+                                <button 
+                                    type="button"
+                                    onclick="openEditModal(this)"
+                                    data-id="<?= $row['machine_id'] ?>"
+                                    data-control="<?= htmlspecialchars($row['control_no'], ENT_QUOTES) ?>"
+                                    data-description="<?= $row['description'] ?>"
+                                    data-model="<?= htmlspecialchars($row['model'], ENT_QUOTES) ?>"
+                                    data-maker="<?= htmlspecialchars($row['maker'], ENT_QUOTES) ?>"
+                                    data-serial="<?= htmlspecialchars($row['serial_no'], ENT_QUOTES) ?>"
+                                    data-invoice="<?= htmlspecialchars($row['invoice_no'], ENT_QUOTES) ?>"
+                                >✏️</button>
 
                                     <!-- Delete form -->
                                     <form action="/SOMS/app/controllers/delete_machine.php" method="POST" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this machine?');">
@@ -126,6 +139,41 @@ include_once __DIR__ . '/../includes/header.php'; // Include the header file for
 
         <hr>
 
+        <!-- Edit Machine Modal -->
+        <div id="editModal" style="display:none; position:fixed; top:10%; left:50%; transform:translateX(-50%);
+            background:#fff; padding:20px; border:1px solid #ccc; box-shadow:0 0 10px rgba(0,0,0,0.2); z-index:999;">
+            
+            <form id="editMachineForm" action="../controllers/edit_machine.php" method="POST">
+                <input type="hidden" name="machine_id" id="edit_machine_id">
+
+                <h2>Edit Machine</h2>
+
+                <label>Control No:</label>
+                <input type="text" name="control_no" id="edit_control_no" required><br><br>
+
+                <label>Description:</label>
+                <select name="description" id="edit_description" required>
+                    <option value="">--Select--</option>
+                    <option value="AUTOMATIC">AUTOMATIC</option>
+                    <option value="SEMI-AUTOMATIC">SEMI-AUTOMATIC</option>
+                </select><br><br>
+
+                <label>Model:</label>
+                <input type="text" name="model" id="edit_model" required><br><br>
+
+                <label>Maker:</label>
+                <input type="text" name="machine_maker" id="edit_maker" required><br><br>
+
+                <label>Serial No:</label>
+                <input type="text" name="serial_no" id="edit_serial_no"><br><br>
+
+                <label>Invoice No:</label>
+                <input type="text" name="invoice_no" id="edit_invoice_no"><br><br>
+
+                <button type="submit">Save</button>
+                <button type="button" onclick="closeModal()">Cancel</button>
+            </form>
+        </div>
 
         <!-- Add Applicator Form -->
         <form action="../controllers/add_applicator.php" method="POST">

--- a/public/assets/js/edit_machine_modal.js
+++ b/public/assets/js/edit_machine_modal.js
@@ -1,0 +1,18 @@
+// Modal Logic for Editing Machines
+function openEditModal(button) {
+    // Get values from button
+    document.getElementById('edit_machine_id').value = button.dataset.id;
+    document.getElementById('edit_control_no').value = button.dataset.control;
+    document.getElementById('edit_description').value = button.dataset.description;
+    document.getElementById('edit_model').value = button.dataset.model;
+    document.getElementById('edit_maker').value = button.dataset.maker;
+    document.getElementById('edit_serial_no').value = button.dataset.serial;
+    document.getElementById('edit_invoice_no').value = button.dataset.invoice;
+
+    // Show modal
+    document.getElementById('editModal').style.display = 'block';
+}
+
+function closeModal() {
+    document.getElementById('editModal').style.display = 'none';
+}

--- a/public/assets/js/load_machines.js
+++ b/public/assets/js/load_machines.js
@@ -50,10 +50,26 @@ function loadMachines() {
             const tdActions = document.createElement('td');
 
             // Edit link
-            const editLink = document.createElement('a');
-            editLink.href = '/SOMS/controllers/edit_machine.php?id=' + row.machine_id;
-            editLink.textContent = '✏️';
-            tdActions.appendChild(editLink);
+            const editButton = document.createElement('button');
+            editButton.textContent = '✏️';
+            editButton.setAttribute('type', 'button');
+            editButton.setAttribute('class', 'edit-machine-button');
+
+            // Set data attributes
+            editButton.dataset.id = row.machine_id;
+            editButton.dataset.control = row.control_no;
+            editButton.dataset.description = row.description;
+            editButton.dataset.model = row.model;
+            editButton.dataset.maker = row.maker;
+            editButton.dataset.serial = row.serial_no;
+            editButton.dataset.invoice = row.invoice_no;
+
+            // Attach event listener
+            editButton.addEventListener('click', function () {
+                openEditModal(editButton);
+            });
+
+            tdActions.appendChild(editButton);
             
             // Delete form
             const deleteForm = document.createElement('form');


### PR DESCRIPTION
### Summary
This PR adds a modal interface for editing machine records from the UI. The modal is pre-populated with existing machine data and is fully styled and functional on the frontend. This feature currently supports display and user interaction only — no data is submitted or saved yet. Backend integration will be handled in a future update.