### PR TITLE
Implement backend logic for editing applicators via modal form

### DIFF
--- a/app/controllers/edit_applicator.php
+++ b/app/controllers/edit_applicator.php
@@ -1,0 +1,70 @@
+<?php
+/*
+    This script handles the editing logic for an existing applicator in the database.
+    It retrieves form data, sanitizes it, and updates the database record.
+*/
+
+// Start session and check if user is logged in
+session_start(); 
+if (!isset($_SESSION['user_id'])) {
+    header("Location: ../views/login.php");
+    exit();
+}
+
+// Include necessary files
+require_once '../includes/js_alert.php';
+include_once '../models/update_applicator.php';
+
+// Check if the request method is POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    jsAlertRedirect("Invalid request method.", "../views/add_entry.php");
+    exit;
+}
+
+// Redirect url
+$redirect_url = "../views/add_entry.php";
+
+// 1. Sanitize input
+$applicator_id = isset($_POST['applicator_id']) ? intval($_POST['applicator_id']) : null;
+$control_no = isset($_POST['control_no']) ? strtoupper(trim($_POST['control_no'])) : null;
+$terminal_no = isset($_POST['terminal_no']) ? strtoupper(trim($_POST['terminal_no'])) : null;
+$description = isset($_POST['description']) ? strtoupper(trim($_POST['description'])) : null;
+$wire_type = isset($_POST['wire_type']) ? strtoupper(trim($_POST['wire_type'])) : null;
+$terminal_maker = isset($_POST['terminal_maker']) ? strtoupper(trim($_POST['terminal_maker'])) : null;
+$applicator_maker = isset($_POST['applicator_maker']) ? strtoupper(trim($_POST['applicator_maker'])) : null;
+$serial_no = empty($_POST['serial_no']) ? 'NO RECORD' : strtoupper(trim($_POST['serial_no']));
+$invoice_no = empty($_POST['invoice_no']) ? 'NO RECORD' : strtoupper(trim($_POST['invoice_no']));
+
+// 2. Validation
+if (empty($applicator_id) || empty($control_no) || empty($terminal_no) || empty($description) || 
+    empty($wire_type) || empty($terminal_maker) || empty($applicator_maker)) {
+    jsAlertRedirect("Please fill in all required fields.", $redirect_url);
+    exit;
+}
+
+if ($description !== 'SIDE' && $description !== 'END') {
+    jsAlertRedirect("Invalid selection for description.", $redirect_url);
+    exit;
+}
+
+if ($wire_type !== 'BIG' && $wire_type !== 'SMALL') {
+    jsAlertRedirect("Invalid selection for wire type.", $redirect_url);
+    exit;
+} 
+
+// 3. Database operation
+$result = updateApplicator($applicator_id, $control_no, $terminal_no, $description, 
+                            $wire_type, $terminal_maker, $applicator_maker, 
+                            $serial_no, $invoice_no);
+
+// Check if applicator update was successful
+if ($result === true) {
+    jsAlertRedirect("Applicator updated successfully!", $redirect_url);
+    exit;
+} elseif (is_string($result)) {
+    jsAlertRedirect($result, $redirect_url);
+    exit;
+} else {
+    jsAlertRedirect("Failed to update applicator. Please try again.", $redirect_url);
+    exit;
+}

--- a/app/models/update_applicator.php
+++ b/app/models/update_applicator.php
@@ -1,0 +1,75 @@
+<?php
+/*
+    This script handles the UPDATE operation for applicators in the database.
+    It includes a function to update applicator data in the database.
+*/
+
+// Include the database connection
+require_once __DIR__ . '/../includes/db.php';
+
+function updateApplicator($applicator_id, $control_no, $terminal_no, $description, 
+                        $wire_type, $terminal_maker, $applicator_maker, 
+                        $serial_no, $invoice_no) {
+    /*
+    Function to update an existing applicator in the database.
+
+    Args:
+    - $applicator_id: ID of the applicator to update.
+    - $control_no: Control number of the applicator.
+    - $terminal_no: Terminal number of the applicator.
+    - $description: Description of the applicator (SIDE/END).
+    - $wire_type: Type of wire used in the applicator (BIG/SMALL).
+    - $terminal_maker: Maker of the terminal.
+    - $applicator_maker: Maker of the applicator.
+    - $serial_no: Serial number of the applicator.
+    - $invoice_no: Invoice number associated with the applicator.
+
+    Returns:
+    - true on successful operation.
+    - string containing error message and redirect using JS <alert>.
+    */
+
+    global $pdo;
+    
+    // Set serial_no and invoice_no to null if empty or "NO RECORD"
+    $serial_no = $serial_no === 'NO RECORD' ? null : $serial_no;
+    $invoice_no = $invoice_no === 'NO RECORD' ? null : $invoice_no;
+
+    try {
+        // Prepare SQL update query
+        $stmt = $pdo->prepare("
+            UPDATE applicators SET
+                hp_no = :control_no,
+                terminal_no = :terminal_no,
+                description = :description,
+                wire = :wire_type,
+                terminal_maker = :terminal_maker,
+                applicator_maker = :applicator_maker,
+                serial_no = :serial_no,
+                invoice_no = :invoice_no
+            WHERE applicator_id = :applicator_id
+        ");
+
+        // Bind parameters
+        $stmt->bindParam(':applicator_id', $applicator_id);
+        $stmt->bindParam(':control_no', $control_no);
+        $stmt->bindParam(':terminal_no', $terminal_no);
+        $stmt->bindParam(':description', $description);
+        $stmt->bindParam(':wire_type', $wire_type);
+        $stmt->bindParam(':terminal_maker', $terminal_maker);
+        $stmt->bindParam(':applicator_maker', $applicator_maker);
+        $stmt->bindParam(':serial_no', $serial_no, PDO::PARAM_NULL | PDO::PARAM_STR);
+        $stmt->bindParam(':invoice_no', $invoice_no, PDO::PARAM_NULL | PDO::PARAM_STR);
+
+        // Execute the statement
+        if ($stmt->execute()) {
+            return true; // Success
+        } else {
+            return "Failed to update applicator. Please try again.";
+        }
+    } catch (PDOException $e) {
+        // Log error and return an error message on failure
+        error_log("Database Error in updateApplicator: " . $e->getMessage());
+        return "Database error in updateApplicator: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/views/add_entry.php
+++ b/app/views/add_entry.php
@@ -286,6 +286,7 @@ include_once __DIR__ . '/../includes/header.php'; // Include the header file for
             background:#fff; padding:20px; border:1px solid #ccc; box-shadow:0 0 10px rgba(0,0,0,0.2); z-index:999;">
             
             <form id="editApplicatorForm" action="../controllers/edit_applicator.php" method="POST">
+                <!-- Hidden input to store applicator ID -->
                 <input type="hidden" name="applicator_id" id="edit_applicator_id">
 
                 <h2>Edit Applicator</h2>


### PR DESCRIPTION
### Summary
This PR implements the backend functionality to handle editing of applicator records via the modal form. It includes:
- Extraction of `applicator_id` from the form as a hidden input
- Updated SQL query to bind all relevant fields, including serial and invoice numbers
- Fix for missing parameter binding for `:applicator_id`
