### PR TITLE
Implement backend logic for editing machines via modal form

### DIFF
--- a/app/controllers/edit_machine.php
+++ b/app/controllers/edit_machine.php
@@ -1,0 +1,62 @@
+<?php
+/*
+    This script handles the editing logic for an existing machine in the database.
+    It retrieves form data, sanitizes it, and updates the database record.
+*/
+
+// Start session and check if user is logged in
+session_start(); 
+if (!isset($_SESSION['user_id'])) {
+    header("Location: ../views/login.php");
+    exit();
+}
+
+// Include necessary files
+require_once '../includes/js_alert.php';
+include_once '../models/update_machine.php';
+
+// Redirect url
+$redirect_url = "../views/add_entry.php";
+
+// Check if the request method is POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    jsAlertRedirect("Invalid request method.", $redirect_url);
+    exit;
+}
+
+// 1. Sanitize input
+$machine_id = isset($_POST['machine_id']) ? intval($_POST['machine_id']) : null;
+$control_no = isset($_POST['control_no']) ? strtoupper(trim($_POST['control_no'])) : null;
+$description = isset($_POST['description']) ? strtoupper(trim($_POST['description'])) : null;
+$model = isset($_POST['model']) ? strtoupper(trim($_POST['model'])) : null;
+$machine_maker = isset($_POST['machine_maker']) ? strtoupper(trim($_POST['machine_maker'])) : null;
+$serial_no = empty($_POST['serial_no']) ? 'NO RECORD' : strtoupper(trim($_POST['serial_no']));
+$invoice_no = empty($_POST['invoice_no']) ? 'NO RECORD' : strtoupper(trim($_POST['invoice_no']));
+
+// 2. Validation
+if (empty($machine_id) || empty($control_no) || empty($description) ||
+    empty($model) || empty($machine_maker)) {
+    jsAlertRedirect("Please fill in all required fields.", $redirect_url);
+    exit;
+}
+
+if ($description !== 'AUTOMATIC' && $description !== 'SEMI-AUTOMATIC') {
+    jsAlertRedirect("Invalid selection for description.", $redirect_url);
+    exit;
+}
+
+// 3. Database operation
+$result = updateMachine($machine_id, $control_no, $description, $model,
+                        $machine_maker, $serial_no, $invoice_no);
+
+// Check if machine update was successful
+if ($result === true) {
+    jsAlertRedirect("machine updated successfully!", $redirect_url);
+    exit;
+} elseif (is_string($result)) {
+    jsAlertRedirect($result, $redirect_url);
+    exit;
+} else {
+    jsAlertRedirect("Failed to update machine. Please try again.", $redirect_url);
+    exit;
+}

--- a/app/models/update_machine.php
+++ b/app/models/update_machine.php
@@ -1,0 +1,68 @@
+<?php
+/*
+    This script handles the UPDATE operation for machines in the database.
+    It includes a function to update machine data in the database.
+*/
+
+// Include the database connection
+require_once __DIR__ . '/../includes/db.php';
+
+function updateMachine($machine_id, $control_no, $description, $model,  
+                        $machine_maker, $serial_no, $invoice_no) {
+    /*
+    Function to update an existing machine in the database.
+
+    Args:
+    - $machine_id: ID of the machine to update.
+    - $control_no: Control number of the machine.
+    - $description: Description of the machine (AUTOMATIC/SEMI-AUTOMATIC).
+    - $model: Model of the machine.
+    - $machine_maker: Maker of the machine.
+    - $serial_no: Serial number of the machine.
+    - $invoice_no: Invoice number associated with the machine.
+
+    Returns:
+    - true on successful operation.
+    - string containing error message and redirect using JS <alert>.
+    */
+
+    global $pdo;
+    
+    // Set serial_no and invoice_no to null if empty or "NO RECORD"
+    $serial_no = $serial_no === 'NO RECORD' ? null : $serial_no;
+    $invoice_no = $invoice_no === 'NO RECORD' ? null : $invoice_no;
+
+    try {
+        // Prepare SQL update query
+        $stmt = $pdo->prepare("
+            UPDATE machines SET
+                control_no = :control_no,
+                description = :description,
+                model = :model,
+                maker = :machine_maker,
+                serial_no = :serial_no,
+                invoice_no = :invoice_no
+            WHERE machine_id = :machine_id
+        ");
+
+        // Bind parameters
+        $stmt->bindParam(':machine_id', $machine_id);
+        $stmt->bindParam(':control_no', $control_no);
+        $stmt->bindParam(':description', $description);
+        $stmt->bindParam(':model', $model);
+        $stmt->bindParam(':machine_maker', $machine_maker);
+        $stmt->bindParam(':serial_no', $serial_no, PDO::PARAM_NULL | PDO::PARAM_STR);
+        $stmt->bindParam(':invoice_no', $invoice_no, PDO::PARAM_NULL | PDO::PARAM_STR);
+
+        // Execute the statement
+        if ($stmt->execute()) {
+            return true; // Success
+        } else {
+            return "Failed to update machine. Please try again.";
+        }
+    } catch (PDOException $e) {
+        // Log error and return an error message on failure
+        error_log("Database Error in updateMachine: " . $e->getMessage());
+        return "Database error in updateMachine: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}


### PR DESCRIPTION
### Summary
This PR implements the backend functionality to handle editing of applicator records via the modal form. It includes:

### Changes
- Extraction of machine_id from the form as a hidden input
- Controller to handle input data for editting a machiner in the database
- Model function to edit a machine in the database
- Updated SQL query to bind all relevant machine fields