### PR TITLE
Implement initial loading of production records with join across applicators and machine outputs

### DIFF
--- a/app/includes/config.php
+++ b/app/includes/config.php
@@ -1,7 +1,4 @@
 <?php
-// Base URL for redirects and links
-define('BASE_URL', '/SOMS/app/');
-
 // Database settings
 define('DB_HOST', 'localhost');
 define('DB_NAME', 'machine_and_applicator');

--- a/app/models/read_joins/record_and_outputs.php
+++ b/app/models/read_joins/record_and_outputs.php
@@ -1,0 +1,69 @@
+<?php
+/*
+    This file defines a function that queries a list of machines from the database.
+    Used in the machine listing with pagination, such as in infinite scroll.
+*/
+
+// Include the database connection
+require_once __DIR__ . '/../../includes/db.php'; 
+
+function getRecordsAndOutputs(int $limit = 10, int $offset = 0): array {
+    /*
+    Function to fetch a list of machines from the database with pagination.
+    It prepares and executes a SELECT query that fetches machines ordered by most recent,
+    and returns them as an associative array.
+
+    Args:
+    - $pdo: PDO database connection object.
+    - $limit: Maximum number of rows to fetch (default is 10).
+    - $offset: Number of rows to skip (default is 0), used for pagination.
+
+    Returns:
+    - Array of machines (associative arrays) on success.
+    */
+
+    global $pdo;
+
+    // Prepare the SQL statement with placeholders for limit and offset
+    $stmt = $pdo->prepare("
+        SELECT 
+            r.record_id AS record_id,
+            r.shift AS shift,
+            r.date_inspected AS date_inspected,
+            r.date_encoded AS date_encoded,
+
+            ao1.total_output AS app1_output,
+            ao2.total_output AS app2_output,
+
+            mo.total_machine_output AS machine_output,
+
+            a1.hp_no AS hp1_no,
+            a2.hp_no AS hp2_no,
+
+            m.control_no AS control_no
+
+        FROM records r
+        LEFT JOIN applicator_outputs ao1 ON r.applicator1_id = ao1.applicator_output_id
+        LEFT JOIN applicator_outputs ao2 ON r.applicator2_id = ao2.applicator_output_id
+
+        LEFT JOIN machine_outputs mo ON r.machine_id = mo.machine_output_id
+
+        LEFT JOIN applicators a1 ON r.applicator1_id = a1.applicator_id
+        LEFT JOIN applicators a2 ON r.applicator2_id = a2.applicator_id
+
+        LEFT JOIN machines m ON r.machine_id = m.machine_id
+
+        WHERE r.is_active = 1
+        ORDER BY r.record_id DESC
+        LIMIT :limit OFFSET :offset
+    ");
+
+    // Bind pagination parameters securely
+    $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+
+    // Execute the query and return the results
+    $stmt->execute();
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+

--- a/app/views/record_output.php
+++ b/app/views/record_output.php
@@ -11,8 +11,6 @@ if (!isset($_SESSION['user_id'])) {
     header('Location: login.php');
     exit();
 }
-
-include_once __DIR__ . '/../includes/header.php'; // Include the header file for the navigation and logo
 */
 ?>
 
@@ -23,7 +21,7 @@ include_once __DIR__ . '/../includes/header.php'; // Include the header file for
 <head>
     <meta charset="UTF-8">
     <title>Record Output</title>
-    <link rel="stylesheet" href="../../public/assets/css/record_output.css">
+    <link rel="stylesheet" href="../../public/assets/css/record_output.css" >
 </head>
 <body>
     <div class="form-container">
@@ -159,6 +157,60 @@ include_once __DIR__ . '/../includes/header.php'; // Include the header file for
                 </button>
             </div>
         </form>
+    </div>
+
+    <!-- Table for displaying recent records --> 
+    <div>
+        <h3>Latest Records</h3>
+
+        <!-- Scrollable container for infinite scrolling -->
+        <div id="records-table" style="height: 300px; overflow-y: auto;">
+        <table class="entries-table">
+            <thead>
+                <tr>
+                    <th>Record ID</th>
+                    <th>Date Inspected</th>
+                    <th>Date Encoded</th>
+                    <th>Shift</th>
+                    <th>Applicator1</th>
+                    <th>App1 Output</th>
+                    <th>Applicator2</th>
+                    <th>App2 Output</th>
+                    <th>Machine</th>
+                    <th>Machine Output</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+
+                <?php
+                // Include database connection and machine reader logic
+                require_once __DIR__ . '/../includes/db.php';
+                require_once __DIR__ . '/../models/read_joins/record_and_outputs.php';
+
+                // Fetch initial set of machines (first 10 entries)
+                $records = getRecordsAndOutputs(10, 0);
+                ?>
+
+                <tbody id="machinesTanleBody">
+                    <!-- Render fetched machine data as table rows -->
+                    <?php foreach ($records as $row): ?>
+                        <tr>
+                            <td><?= htmlspecialchars($row['record_id']) ?></td>
+                            <td><?= htmlspecialchars($row['date_inspected']) ?></td>
+                            <td><?= htmlspecialchars($row['date_encoded']) ?></td>
+                            <td><?= htmlspecialchars($row['shift']) ?></td>
+                            <td><?= htmlspecialchars($row['hp1_no']) ?></td>
+                            <td><?= htmlspecialchars($row['app1_output']) ?></td>
+                            <td><?= htmlspecialchars($row['hp2_no']) ?></td>
+                            <td><?= htmlspecialchars($row['app2_output']) ?></td>
+                            <td><?= htmlspecialchars($row['control_no']) ?></td>
+                            <td><?= htmlspecialchars($row['machine_output']) ?></td>
+                            <td>✏️🗑️</td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
### Summary
This update sets up the backend and frontend for initially displaying the first 10 production records. The records are retrieved using a join across related tables: `applicator_outputs`, `machine_outputs`, and `applicators`, allowing richer detail to be shown in the view.

### Changes Included
- Created model `getRecordsAndOutputs()` to join and fetch paginated records
- Corrected `require_once` paths in model files
- Integrated the initial data load into the `record_output.php` view
- Displayed results in a scrollable table container

### Next Steps
- Implement AJAX for infinite scroll or load-more functionality
- Edit/delete actions functionality per row.
