### PR TITLE
fix: add missing options for applicator type

### DIFF
--- a/app/controllers/add_applicator.php
+++ b/app/controllers/add_applicator.php
@@ -43,7 +43,8 @@ if (empty($control_no) || empty($terminal_no) || empty($description) ||
     exit;
 }
 
-if ($description !== 'SIDE' && $description !== 'END') {
+if ($description !== 'SIDE' && $description !== 'END'  && $description !== 'CLAMP'  
+    && $description !== 'STRIP AND CRIMP' ) {
     jsAlertRedirect("Invalid selection for description.", $redirect_url);
     exit;
 }


### PR DESCRIPTION
### Summary
This PR adds the missing options for applicator type in the controllers directory. Future commits should include frontend fix to add "CLAMP" and "STRIP AND CRIMP" to 'add applicator' forms.