### PR TITLE
Schema: Add columns to support reset undo functionality

### DIFF
--- a/app/sql/database.sql
+++ b/app/sql/database.sql
@@ -208,28 +208,34 @@ CREATE TABLE machine_reset (
     reset_id INT PRIMARY KEY AUTO_INCREMENT,
     machine_id INT NOT NULL,
     reset_by INT NOT NULL,
-    part_reset VARCHAR(50) NOT NULL, -- Can be standard part name or custom part code
+    part_reset VARCHAR(50) NOT NULL, -- standard part name or custom part code
+    previous_value INT NOT NULL, -- Store the value before reset
     reset_time DATETIME DEFAULT CURRENT_TIMESTAMP,
-    remarks TEXT DEFAULT NULL,
+    undone_by INT DEFAULT NULL, -- who undid this reset
+    undone_time DATETIME DEFAULT NULL, -- when it was undone
 
     FOREIGN KEY (machine_id) REFERENCES machines(machine_id),
     FOREIGN KEY (reset_by) REFERENCES users(user_id),
+    FOREIGN KEY (undone_by) REFERENCES users(user_id),
 
     INDEX idx_machine_id (machine_id),
-    INDEX idx_reset_time (reset_time)
+    INDEX idx_reset_time (reset_time),
 );
 
 CREATE TABLE applicator_reset (
     reset_id INT PRIMARY KEY AUTO_INCREMENT,
     applicator_id INT NOT NULL,
     reset_by INT NOT NULL,
-    part_reset VARCHAR(50) NOT NULL, -- Can be standard part name or custom part code
+    part_reset VARCHAR(50) NOT NULL, -- standard part name or custom part code
+    previous_value INT NOT NULL, -- Store the value before reset
     reset_time DATETIME DEFAULT CURRENT_TIMESTAMP,
-    remarks TEXT DEFAULT NULL,
+    undone_by INT DEFAULT NULL, -- who undid this reset
+    undone_time DATETIME DEFAULT NULL, -- when it was undone
 
     FOREIGN KEY (applicator_id) REFERENCES applicators(applicator_id),
     FOREIGN KEY (reset_by) REFERENCES users(user_id),
+    FOREIGN KEY (undone_by) REFERENCES users(user_id),
 
     INDEX idx_applicator_id (applicator_id),
-    INDEX idx_reset_time (reset_time)
+    INDEX idx_reset_time (reset_time),
 );

--- a/app/sql/db_documentation.md
+++ b/app/sql/db_documentation.md
@@ -224,8 +224,11 @@ This database system is designed to track machine and applicator usage in a manu
 | `machine_id` | INT | NOT NULL, FK → machines | Machine that was reset |
 | `reset_by` | INT | NOT NULL, FK → users | User who performed the reset |
 | `part_reset` | VARCHAR(50) | NOT NULL | Part that was reset (standard name or custom code, 'ALL' for full reset) |
+| `previous_value` | INT | NOT NULL | Value before reset |
 | `reset_time` | DATETIME | DEFAULT CURRENT_TIMESTAMP | When reset occurred |
-| `remarks` | TEXT | DEFAULT NULL | Optional notes about the reset |
+
+| `undone_by` | INT | DEFAULT NULL, FK → users | User who undid the reset |
+| `undone_time` | DATETIME | DEFAULT NULL | When reset was undone |
 
 **Indexes**: `idx_machine_id`, `idx_reset_time`
 
@@ -240,9 +243,11 @@ This database system is designed to track machine and applicator usage in a manu
 | `reset_id` | INT | PRIMARY KEY, AUTO_INCREMENT | Unique identifier |
 | `applicator_id` | INT | NOT NULL, FK → applicators | Applicator that was reset |
 | `reset_by` | INT | NOT NULL, FK → users | User who performed the reset |
+| `previous_value` | INT | NOT NULL | Value before reset |
 | `part_reset` | VARCHAR(50) | NOT NULL | Part that was reset (standard name or custom code, 'ALL' for full reset) |
 | `reset_time` | DATETIME | DEFAULT CURRENT_TIMESTAMP | When reset occurred |
-| `remarks` | TEXT | DEFAULT NULL | Optional notes about the reset |
+| `undone_by` | INT | DEFAULT NULL, FK → users | User who undid the reset |
+| `undone_time` | DATETIME | DEFAULT NULL | When reset was undone |
 
 **Indexes**: `idx_applicator_id`, `idx_reset_time`
 


### PR DESCRIPTION
### Summary
This PR adds the necessary database columns to support undo functionality for machine and applicator resets. **This is a schema-only change - the actual undo implementation will be added in a follow-up PR.**

### Changes 
- **Added `previous_value` column**: Will store the cumulative output value before reset
- **Added undo tracking columns**: New `undone_by` and `undone_time` columns for future undo tracking
- **Removed `remarks` column**: Simplified the schema by removing unused field
- **Updated foreign keys**: Added proper referential integrity for the `undone_by` field

### Next Steps
- Implement reset and undo logic 