### PR TITLE
feat: add models for resetting applicator parts and logging reset history

### DIFF
--- a/app/models/create_applicator_reset.php
+++ b/app/models/create_applicator_reset.php
@@ -1,0 +1,50 @@
+<?php 
+/* 
+    This file contains functiions to create an entry on the applicator_reset table.
+*/
+
+
+function createApplicatorReset($user_id, $applicator_id, $part_reset, $previous_value) {
+    /*
+        Function to record applicator_part resets.
+
+        Args:
+        - $user_id - int pertaining to a user in the users table
+        - $applicator_id - int pertaining to a applicator in the users applicators table
+        - $part_reset - part name to reset
+        - $previous_value - previous total value before reset
+
+        Returns:
+        - true on success
+        - string containing error message
+    */
+
+    global $pdo;
+
+    // Main logic
+    try {
+        $stmt = $pdo->prepare("
+            INSERT INTO applicator_reset (applicator_id, reset_by, part_reset, 
+                    previous_value, reset_time)
+            VALUES (:applicator_id, :reset_by, :part_reset, 
+                    :previous_value, now())
+        ");
+
+        // Bind parameters
+        $stmt->bindParam(':applicator_id', $applicator_id);
+        $stmt->bindParam(':reset_by', $user_id);
+        $stmt->bindParam(':part_reset', $part_reset);
+        $stmt->bindParam(':previous_value', $previous_value);
+
+        // Execute the statement
+        $stmt->execute();
+        
+        return true; // Success
+
+    
+    } catch (PDOException $e) {
+        // Log error and return an error message on failure
+        error_log("Database Error in createApplicatorReset: " . $e->getMessage());
+        return "Database error in createApplicatorReset: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/models/update_monitor_applicator.php
+++ b/app/models/update_monitor_applicator.php
@@ -1,10 +1,16 @@
 <?php
 /*
-    Updates or inserts applicator monitoring data into the `monitor_applicator` table.
-    Automatically handles both SIDE-type and END/CLAMP/STRIP AND CRIMP-type applicators,
-    including increment or decrement logic for outputs and updating custom parts.
+    This file contains functions that updaates the monitoring data for applicators.
 */
+
+
 function monitorApplicatorOutput($applicator_data, $applicator_output, $direction = "increment") {
+    /*
+        Updates or inserts applicator monitoring data into the `monitor_applicator` table.
+        Automatically handles both SIDE-type and END/CLAMP/STRIP AND CRIMP-type applicators,
+        including increment or decrement logic for outputs and updating custom parts.
+    */
+
     global $pdo;
 
     try {
@@ -122,5 +128,68 @@ function monitorApplicatorOutput($applicator_data, $applicator_output, $directio
         // Log and return a sanitized error
         error_log("DB Error in monitorApplicatorOutput(): " . $e->getMessage());
         return "Database error: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}
+
+
+
+function resetApplicatorOutput($applicator_id, $part_name) {
+    /*
+        Resets the output for a specific part of an applicator in the monitor_applicator table.
+        Includes part reset for defined and custom parts.
+
+        Returns:
+        - true on success 
+        - error string
+    */
+
+    global $pdo;
+    
+    $accepted_part_names = [
+        'wire_crimper_output',
+        'wire_anvil_output',
+        'insulation_crimper_output',
+        'insulation_anvil_output',
+        'slide_cutter_output',
+        'cutter_holder_output',
+        'shear_blade_output',
+        'cutter_a_output',
+        'cutter_b_output'];
+    
+    // Get custom applicator parts 
+    require_once "read_custom_parts.php";
+    $custom_parts = getCustomParts("APPLICATOR");
+
+    // Return error message if any issue occurs
+    if (is_string($custom_parts)) {
+        return $custom_parts;
+    }
+
+    foreach ($custom_parts as $row) {
+        $accepted_part_names[] = $row["part_name"];
+    }
+
+    // Check if given part_name is accepted 
+    if (!in_array($accepted_part_names)) {
+        return "Reset cancelled: invalid part name!"
+    }
+
+    // Execute main logic 
+    try {
+        $stmt = $pdo->prepare("
+            UPDATE monitor applicators
+            SET $part_name = 0,
+            WHERE applicator_id = :applicator_id
+        ")
+
+        $stmt->bindParam(':applicator_id', $applicator_id);
+        $stmt->execute();
+
+        return true;
+
+    } catch (PDOException $e) {
+        // Log error and return an error message on failure
+        error_log("Database Error in resetApplicatorOutput: " . $e->getMessage());
+        return "Database error in resetApplicatorOutput: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
     }
 }


### PR DESCRIPTION
### Summary
This PR introduces two new models to handle applicator part resets:

### Additions:
**`resetApplicatorOutput()`**
- Resets the output count of a specified applicator part.
- Supports both predefined and custom applicator parts.
- Ensures validation against accepted part names to prevent SQL injection.

**`createApplicatorReset()`**
- Creates an entry in the applicator_reset table whenever a reset is performed.
- Logs key details such as:
  - applicator_id
  - reset_by (user ID)
  - part_reset (part name)
  - previous_value (before reset)
  - reset_time (timestamp)