### PR TITLE
feature: applicator-dashboard/undo-reset modal population

### DIFF
--- a/app/controllers/get_reset_dates.php
+++ b/app/controllers/get_reset_dates.php
@@ -1,0 +1,20 @@
+<?php
+/*
+    This file will be used to display available timestamps for applicator part output reset via AJAX.
+*/
+
+
+require_once '../models/read_applicator_reset.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $part_name = $_POST['part_name'] ?? null;
+    $applicator_id = $_POST['applicator_id'] ?? null;
+
+    if (!$part_name || !$applicator_id) {
+        echo json_encode([]);
+        exit;
+    }
+
+    $resets = getApplicatorReset($applicator_id, $part_name);
+    echo json_encode($resets);
+}

--- a/app/models/read_applicator_reset.php
+++ b/app/models/read_applicator_reset.php
@@ -1,0 +1,36 @@
+<?php
+/*
+    This file defines functions that query (READ) the applicator_reset table from the database.
+*/
+
+// Include the database connection
+require_once __DIR__ . '/../includes/db.php'; 
+
+function getApplicatorReset($applicator_id, $part_name) {
+    /*
+    Retrieve applicator_reset records for a specific applicator and part.
+
+    Args:
+    - $applicator_id : int, 
+    - $part_name: string, name of applicator part
+
+    Returns:
+    - array: Associative array of applicator_reset records (empty array if none)
+    */
+
+    global $pdo;
+
+    $stmt = $pdo->prepare("
+        SELECT *
+        FROM applicator_reset
+        WHERE applicator_id = :applicator_id
+            AND part_reset = :part_reset
+        ORDER BY reset_time DESC
+    ");
+
+    $stmt->bindValue(':applicator_id', $applicator_id, PDO::PARAM_INT);
+    $stmt->bindValue(':part_reset', $part_name, PDO::PARAM_STR);
+    $stmt->execute();
+
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}

--- a/app/views/dashboard_applicator.php
+++ b/app/views/dashboard_applicator.php
@@ -199,7 +199,13 @@
                                                     data-id="<?= $row['applicator_id'] ?>">
                                                     Reset
                                                 </button>
-                                                <button class="btn-small btn-edit" onclick="openUndoModal()">Undo</button>
+                                                <button
+                                                    class="btn-small btn-edit"
+                                                    type="button"
+                                                    onclick="openUndoModal(this)"
+                                                    data-id="<?= $row['applicator_id'] ?>">
+                                                    Undo
+                                                </button>
                                             </td>
                                             <td><?= htmlspecialchars($row['hp_no']) ?></td>
                                             <td><strong><?= htmlspecialchars(explode(' ', $row['last_updated'])[0]) ?></strong></td>
@@ -310,7 +316,7 @@
                     <div class="form-group">
                         <label class="form-label">⚠️ Are you sure you want to reset the applicator?</label>
                         <p style="color: #6b7280; font-size: 0.9rem; margin-top: 8px;">
-                            This action will reset the selected component's usage counter to zero. This cannot be undone.
+                            This action will reset the selected component's usage counter to zero!
                         </p>
                     </div>
                     <div class="modal-footer">
@@ -326,45 +332,52 @@
     <div id="undoModalDashboardApplicator" class="modal-overlay">
         <div class="modal">
             <div class="modal-header">
-                <h2 class="modal-title">Undo Applicator<span id="editHpNumber"></span></h2>
+                <h2 class="modal-title">Undo Reset<span id="editHpNumber"></span></h2>
             </div>
             <div class="modal-body">
                 <form id="editForm" action="">
                     <div class="form-group">
-                        <label class="form-label">Select Applicator Part to Reset</label>
+                        <!-- Hidden Input for applicator_id -->
+                        <input type="hidden" name="applicator_id" id="undo_applicator_id">
+
+                        <label class="form-label">Select Applicator Part to Undo</label>
                         <select id="editWireType" class="form-input">
-                            <option>Select Part</option>
-                            <option>Wire Crimper</option>
-                            <option>Wire Anvil</option>
-                            <option>Insulation Crimper</option>
-                            <option>Insulation Anvil</option>
-                            <option>Slide Cutter</option>
-                            <option>Cutter Holder</option>
-                            <option>Shear Blade</option>
-                            <option>Cutter A</option>
-                            <option>Cutter B</option>
+                            <option value="">Select Part</option>
+                            <option value="wire_crimper_output">Wire Crimper</option>
+                            <option value="wire_anvil_output">Wire Anvil</option>
+                            <option value="insulation_crimper_output">Insulation Crimper</option>
+                            <option value="insulation_anvil_output">Insulation Anvil</option>
+                            <option value="slide_cutter_output">Slide Cutter</option>
+                            <option value="cutter_holder_output">Cutter Holder</option>
+                            <option value="shear_blade_output">Shear Blade</option>
+                            <option value="cutter_a_output">Cutter A</option>
+                            <option value="cutter_b_output">Cutter B</option>
+                            <?php foreach ($custom_applicator_parts as $row): ?>
+                                <option value="<?= htmlspecialchars($row['part_name']) ?>">
+                                    <?= ucwords(str_replace('_', ' ', htmlspecialchars($row['part_name']))) ?>
+                                </option>
+                            <?php endforeach; ?>
                         </select>
                     </div>
                     
                     <div class="form-group">
                         <label class="form-label">Dates Replaced</label>
                         <select id="editStatus" class="form-input">
-                            <option value="07/21/2025">07/21/2025</option>
-                            <option value="07/22/2025">07/22/2025</option>
-                            <option value="07/23/2025">07/23/2025</option>
-                            <option value="07/24/2025">07/24/2025</option>
-                            <option value="07/25/2025">07/25/2025</option>
-                            <option value="07/26/2025">07/26/2025</option>
-                            <option value="07/27/2025">07/27/2025</option>
-                            <option value="07/28/2025">07/28/2025</option>
-                            <option value="07/29/2025">07/29/2025</option>
+                            <option value="">Select a part first</option>
                         </select>
                     </div>
+
+                    <div>
+                        ⚠️⚠️PROCEED WITH CAUTIION⚠️⚠️ 
+                    </div>
+                    <div>
+                        Reverting to previous timestamp will delete all records encoded later than the timestamp! 
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn-cancel" onclick="closeUndoModal()">Cancel</button>
+                        <button type="button" class="btn-confirm" onclick="saveUndo()">Confirm</button>
+                    </div>
                 </form>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn-cancel" onclick="closeUndoModal()">Cancel</button>
-                <button type="button" class="btn-confirm" onclick="saveUndo()">Confirm</button>
             </div>
         </div>
     </div>

--- a/public/assets/js/dashboard_applicator.js
+++ b/public/assets/js/dashboard_applicator.js
@@ -22,18 +22,28 @@ function closeResetModal() {
 }
 
 // Open the undo modal
-function openUndoModal() {
+function openUndoModal(button) {
+    const applicatorId = button.getAttribute("data-id");
+    document.getElementById("undo_applicator_id").value = applicatorId;
     document.getElementById('undoModalDashboardApplicator').style.display = 'block';
-    window.onclick = function(event) {
-        if (event.target === document.getElementById('undoModalDashboardApplicator')) {
-            document.getElementById('undoModalDashboardApplicator').style.display = 'none';
-        }
-    }
 }
 
 // Close the undo modal
 function closeUndoModal() {
-    document.getElementById('undoModalDashboardApplicator').style.display = 'none';
+    const modal = document.getElementById('undoModalDashboardApplicator');
+
+    // Hide modal
+    modal.style.display = 'none';
+
+    // Reset the form inside modal
+    const form = modal.querySelector('form');
+    if (form) form.reset();
+
+    // Clear the dates dropdown
+    const dropdown = modal.querySelector('#editStatus');
+    if (dropdown) {
+        dropdown.innerHTML = '<option value="">Select a part first</option>';
+    }
 }
 
 // Open the applicator modal
@@ -49,3 +59,43 @@ function openApplicatorModal() {
 function closeApplicatorModal() {
     document.getElementById('applicatorModalDashboardApplicator').style.display = 'none';
 }
+
+
+// Listen for changes in the "part" dropdown
+document.getElementById("editWireType").addEventListener("change", function() {
+    let partName = this.value; // selected part
+    let applicatorId = document.getElementById("undo_applicator_id").value; // hidden input
+
+    // Do nothing if no part is selected
+    if (!partName) return;
+
+    // Send request to server to fetch reset dates for this part + applicator
+    fetch("../controllers/get_reset_dates.php", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: "part_name=" + encodeURIComponent(partName) +
+            "&applicator_id=" + encodeURIComponent(applicatorId)
+    })
+    .then(res => res.json()) // parse JSON response
+    .then(data => {
+        let dropdown = document.getElementById("editStatus");
+        dropdown.innerHTML = ""; // clear old options
+
+        if (data.length > 0) {
+            // Populate dropdown with reset timestamps
+            data.forEach(row => {
+                let option = document.createElement("option");
+                option.value = row.reset_time;
+                option.textContent = row.reset_time;
+                dropdown.appendChild(option);
+            });
+        } else {
+            // If no records found, show fallback option
+            let option = document.createElement("option");
+            option.value = "";
+            option.textContent = "No reset history";
+            dropdown.appendChild(option);
+        }
+    })
+    .catch(err => console.error(err)); // log any errors
+});


### PR DESCRIPTION
### Summary
This PR contains the modal implementation (in views) for undoing a reset action for applicator part outputs.

### Additions
- Implemented dynamic population of undo-reset modal in applicator dashboard
- Added part selection dropdown that fetches reset history per applicator
- Integrated AJAX call (fetch) to retrieve reset timestamps from backend
- Ensured dropdown is cleared and repopulated based on current selection
- Added fallback option when no reset history exists
- Modal state resets on close to prevent old selections from persisting
