### PR TITLE
refactor(undo-reset): replace hard deletes with soft deletes

### DIFF
--- a/app/models/delete_applicator_output.php
+++ b/app/models/delete_applicator_output.php
@@ -42,3 +42,42 @@ function deleteApplicatorOutputs($applicator_id, $record_id) {
         return "Database Error: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
     }
 }
+
+
+function disableApplicatorOutputsByRecordIds(array $record_ids): bool|string {
+    /*
+    Disable applicator_outputs by multiple record_ids in one query.
+
+    Args:
+    - $record_ids: array of record IDs
+
+    Returns:
+    - true on success
+    - error message string on failure
+    */
+    global $pdo;
+
+    try {
+        if (empty($record_ids)) {
+            return true; // nothing to disable
+        }
+
+        // Generate placeholders like ?, ?, ? based on number of IDs
+        $placeholders = implode(',', array_fill(0, count($record_ids), '?'));
+
+        $sql = "UPDATE applicator_outputs SET is_active = 0 WHERE record_id IN ($placeholders)";
+        $stmt = $pdo->prepare($sql);
+
+        // Bind all IDs
+        foreach ($record_ids as $i => $id) {
+            $stmt->bindValue($i + 1, $id, PDO::PARAM_INT);
+        }
+
+        $stmt->execute();
+        return true;
+
+    } catch (PDOException $e) {
+        error_log("Database Error on disableApplicatorOutputsByRecordIds: " . $e->getMessage());
+        return "Database Error on disableApplicatorOutputsByRecordIds: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/models/delete_machine_output.php
+++ b/app/models/delete_machine_output.php
@@ -1,0 +1,48 @@
+<?php
+/*
+    This file contains functions that deletes records from the machine_output table.
+*/
+
+
+function disableMachineOutputsByRecordIds(array $record_ids): bool|string {
+    /*
+    Function to disable (soft delete) multiple machine outputs in the database.
+
+    Args:
+    - $record_ids: array of record IDs to disable
+
+    Returns:
+    - true on success
+    - string containing error message on failure
+    */
+
+    global $pdo;
+
+    try {
+        if (empty($record_ids)) {
+            return true; // nothing to update
+        }
+
+        // Generate placeholders (?, ?, ?, ...)
+        $placeholders = implode(',', array_fill(0, count($record_ids), '?'));
+
+        // Build the SQL
+        $sql = "UPDATE machine_outputs 
+                SET is_active = 0 
+                WHERE record_id IN ($placeholders)";
+
+        $stmt = $pdo->prepare($sql);
+
+        // Bind values
+        foreach ($record_ids as $i => $id) {
+            $stmt->bindValue($i + 1, $id, PDO::PARAM_INT);
+        }
+
+        $stmt->execute();
+        return true;
+
+    } catch (PDOException $e) {
+        error_log("Database Error in disableMachineOutputsByRecordIds(): " . $e->getMessage());
+        return "Database Error: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/models/delete_record.php
+++ b/app/models/delete_record.php
@@ -68,3 +68,39 @@ function deleteRecordEncodedLaterThan($timestamp): bool|string {
         return "Database Error on deleteRecordEncodedLaterThan: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
     }
 }
+
+
+function disableRecordEncodedLaterThan($timestamp): bool|string {
+    /*
+    Function to disable (soft delete) all records encoded later than a timestamp in the database.
+
+    Args:
+    - $timestamp: date_time
+
+    Returns:
+    - true on success
+    - string containing error message on failure
+    */
+    global $pdo;
+
+    try {
+        // Prepare the SQL statement
+        $stmt = $pdo->prepare("
+            UPDATE records 
+            SET is_active = 0
+            WHERE date_encoded > :timestamp
+        ");
+
+        $stmt->bindValue(':timestamp', $timestamp);
+
+        // Execute the statement
+        $stmt->execute();
+
+        return true;
+
+    } catch (PDOException $e) {
+        // Log error
+        error_log("Database Error on disableRecordEncodedLaterThan: " . $e->getMessage());
+        return "Database Error on disableRecordEncodedLaterThan: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/models/read_records.php
+++ b/app/models/read_records.php
@@ -1,0 +1,42 @@
+<?php
+/*
+    This file contains READ operation the records table.
+*/
+
+// Include the database connection
+require_once __DIR__ . '/../includes/db.php';
+
+
+function getRecordsLaterThanTimestamp($timestamp) {
+    /*
+    Fetches all records encoded later than a timestamp in the database.
+
+    Args:
+    - $timestamp: date_time
+
+    Returns:
+    - array of records (possibly empty) on success
+    - string containing error message on failure
+    */
+    global $pdo;
+
+    try {
+        // Prepare the SQL statement
+        $stmt = $pdo->prepare("
+            SELECT * FROM records 
+            WHERE date_encoded > :timestamp
+        ");
+
+        $stmt->bindParam(':timestamp', $timestamp);
+
+        // Execute the statement
+        $stmt->execute(); 
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    } catch (PDOException $e) {
+        // Log error
+        error_log("Database Error on getRecordsLaterThanTimestamp: " . $e->getMessage());
+        return "Database Error on getRecordsLaterThanTimestamp: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}


### PR DESCRIPTION
# Switch from Hard Delete to Soft Delete for Undo-Reset  

## Summary  
This PR updates the **undo-reset** functionality to use **soft delete** instead of hard delete for records generated after a reset.  

## Changes Made  
- Replaced permanent deletion with soft delete (`is_active` flag updates).  
- Applied soft delete to:  
  - `records`  
  - `applicator_outputs`  
  - `machine_outputs`  
- Wrapped operations inside a transaction for consistency.  
- Improved validation and rollback handling to prevent partial updates.  

## Technical Details  
- Previous approach: hard delete (data lost permanently).  
- New approach: soft delete (data disabled but still stored for audit/history).  
- Records later than the reset timestamp are marked inactive, preserving traceability.  

## Benefits  
- Prevents irreversible data loss.  
- Maintains audit/history for debugging and compliance.  