### PR TITLE
feature/manage_user: extend signup logic to support admin user creation with role parameter

### DIFF
--- a/app/controllers/sign_up.php
+++ b/app/controllers/sign_up.php
@@ -7,57 +7,94 @@
 require_once '../includes/js_alert.php'; // Include the JavaScript alert function
 require_once '../includes/db.php'; // Include the database connection
 
-// Redirect url
+// Redirect URL
 $redirect_url = "../views/signup.php";
+if (isset($_POST['admin_create_user'])) {
+    $redirect_url = "../views/manage_user.php";
+}
 
 // Quick Fail
 function failRedirect($message) {
+    global $redirect_url;
     jsAlertRedirect($message, $redirect_url);
     exit;
 }
 
-// Retrieve form data
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    // 1. Sanitize input
-    $firstname = isset($_POST['firstname']) ? trim($_POST['firstname']) : null;
-    $lastname = isset($_POST['lastname']) ? trim($_POST['lastname']) : null;
-    $username = isset($_POST['username']) ? trim($_POST['username']) : null;
-    $password = isset($_POST['password']) ? trim($_POST['password']) : null;
-    $confirm_password = isset($_POST['confirm_password']) ? trim($_POST['confirm_password']) : Null;
+// Check if form is submitted
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    failRedirect("Invalid request.");
+}
 
-    // 2. Validation
-    if (empty($firstname) || empty($lastname) || empty($username) || empty($password) || empty($confirm_password)) {
-        failRedirect("Please fill in all fields.");
+// 1. Sanitize input
+$firstname = isset($_POST['firstname']) ? trim($_POST['firstname']) : null;
+$lastname = isset($_POST['lastname']) ? trim($_POST['lastname']) : null;
+$username = isset($_POST['username']) ? trim($_POST['username']) : null;
+$password = isset($_POST['password']) ? trim($_POST['password']) : null;
+$confirm_password = isset($_POST['confirm_password']) ? trim($_POST['confirm_password']) : null;
+$role = isset($_POST['role']) ? trim($_POST['role']) : null;
+
+// 2. Validation
+if (isset($_POST['admin_create_user'])) {
+    // Admin create user: don't require confirm_password
+    if (empty($firstname) || empty($lastname) || empty($username) || empty($password) || empty($role)) {
+        failRedirect("Please fill in all required fields.");
     }
-    
+} else {
+    // Regular signup: require confirm_password
+    if (empty($firstname) || empty($lastname) || empty($username) || empty($password) || empty($confirm_password)) {
+        failRedirect("Please fill in all required fields.");
+    }
+    // Password confirmation check
     if ($password !== $confirm_password) {
-        // Password confirmation check
         failRedirect("Password Mismatch!");
     }
+}
 
-    // 3. Try to register the user
-    include_once '../models/create_user.php';
-    $pdo->beginTransaction();
-    $result = createUser($firstname, $lastname, $username, $password, $confirm_password);
+// 3. Normalize role
+switch (strtolower($role)) {
+    case 'admin':
+        $role = 'ADMIN';
+        break;
+    case 'toolkeeper':
+        $role = 'TOOLKEEPER';
+        break;
+    case 'default':
+    case 'user':
+    default:
+        $role = 'DEFAULT';
+        break;
+}
 
-    // 4. Handle response
-    if (is_array($result)) {
-        //  Save user data into session to log them in immediately
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
-        $_SESSION['user_id'] = $result['user_id'];
-        $_SESSION['username'] = $result['username'];
-        $_SESSION['first_name'] = $result['first_name'];
-        $_SESSION['user_type'] = $result['user_type'];
-        $pdo->commit();
-        header("Location: ../views/home.php");
-        exit();
-    } elseif (is_string($result)) {
-        $pdo->rollBack();
-        failRedirect($result);
-    } else {
-        $pdo->rollBack();
-        failRedirect("Registration failed. Please try again.");
+// 4. Try to register the user
+$pdo->beginTransaction();
+include_once '../models/create_user.php';
+
+$result = createUser($firstname, $lastname, $username, $password, $confirm_password, $role);
+
+// 5. Handle response
+if (is_array($result)) {
+    // Save user data into session to log them in immediately
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
     }
-} 
+    
+    $_SESSION['user_id'] = $result['user_id'];
+    $_SESSION['username'] = $result['username'];
+    $_SESSION['first_name'] = $result['first_name'];
+    $_SESSION['user_type'] = $result['user_type'];
+    $pdo->commit();
+    if (isset($_POST['admin_create_user'])) {
+        jsAlertRedirect("User created successfully.", $redirect_url);
+    } elseif ($user_type == 'TOOLKEEPER') {
+        header("Location: ../views/record_output.php");
+    } else {
+        header("Location: ../views/dashboard_applicator.php");
+    }
+    exit();
+} elseif (is_string($result)) {
+    $pdo->rollBack();
+    failRedirect($result);
+} else {
+    $pdo->rollBack();
+    failRedirect("Registration failed. Please try again.");
+}

--- a/app/models/create_user.php
+++ b/app/models/create_user.php
@@ -8,17 +8,17 @@
 require_once __DIR__ . '/../includes/db.php'; 
 
 
-function createUser($first_name, $last_name, $username, $password) {
+function createUser($first_name, $last_name, $username, $password, $role = "DEFAULT") {
     /*
         Function to create a new user in the database.
-        It verifies that password and confirm_password match,
-        hashes the password, and inserts the user data into the 'users' table.
+        It hashes the password, and inserts the user data into the 'users' table.
 
         Args:
         - $first_name: The user's first name.
         - $last_name: The user's last name.
+        - $username: The user's username.
         - $password: The password of the user (to be hashed).
-        - $confirm_password: The confirmation password, must match $password.
+        - $role: DEFAULT, TOOLKEEPER, ADMIN
 
         Returns:
         - User data array if the login is successful.
@@ -41,8 +41,8 @@ function createUser($first_name, $last_name, $username, $password) {
 
         // Prepare SQL insert query
         $stmt = $pdo->prepare("
-            INSERT INTO users (first_name, last_name, password, username)
-            VALUES (:first_name, :last_name, :password, :user_name)
+            INSERT INTO users (first_name, last_name, password, username, user_type)
+            VALUES (:first_name, :last_name, :password, :user_name, :role)
         ");
 
         // Bind user input values to placeholders
@@ -50,6 +50,7 @@ function createUser($first_name, $last_name, $username, $password) {
         $stmt->bindParam(':last_name', $last_name);
         $stmt->bindParam(':user_name', $username);
         $stmt->bindParam(':password', $hashedPassword);
+        $stmt->bindParam(':role', $role);
 
         // Execute the statement
         $stmt->execute();

--- a/app/views/manage_user.php
+++ b/app/views/manage_user.php
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/SOMS/public/assets/css/components/header.css">
 </head>
 <body>
-    <?php include '../includes/side_bar.php'; ?>
+    <?php // include '../includes/side_bar.php'; ?>
     <div class="container">
         <!-- Header -->
         <div class="page-header">
@@ -121,7 +121,9 @@
                 <p class="form-subtitle">Enter user information to create a new account</p>
             </div>
 
-            <form id="addUserForm" onsubmit="addUser(event)">
+            <form id="addUserForm" method="POST" action="../controllers/sign_up.php">
+                <input type="hidden" name="admin_create_user" value="admin_create_user">
+
                 <!-- Personal Information Section -->
                 <div class="form-section">
                     <div class="section-header">
@@ -138,7 +140,7 @@
                                 Username
                                 <span class="required-badge">Required</span>
                             </label>
-                            <input type="text" id="addUserName" name="name" class="form-input" placeholder="Enter user name" required>
+                            <input type="text" id="addUserName" name="username" class="form-input" placeholder="Enter user name" required>
                         </div>
                         
                         <div class="form-group">
@@ -146,7 +148,7 @@
                                 First Name
                                 <span class="required-badge">Required</span>
                             </label>
-                            <input type="text" id="addUserFirstName" name="first_name" class="form-input" placeholder="Enter first name" required>
+                            <input type="text" id="addUserFirstName" name="firstname" class="form-input" placeholder="Enter first name" required>
                         </div>
                         
                         <div class="form-group">
@@ -154,7 +156,7 @@
                                 Last Name
                                 <span class="required-badge">Required</span>
                             </label>
-                            <input type="text" id="addUserLastName" name="last_name" class="form-input" placeholder="Enter last name" required>
+                            <input type="text" id="addUserLastName" name="lastname" class="form-input" placeholder="Enter last name" required>
                         </div>
                         
                         <div class="form-group">
@@ -181,19 +183,9 @@
                         <div class="form-group">
                             <label for="addUserRole" class="form-label">User Role</label>
                             <select id="addUserRole" name="role" class="form-input">
-                                <option value="User">User</option>
-                                <option value="Moderator">Moderator</option>
-                                <option value="Admin">Admin</option>
-                            </select>
-                        </div>
-                        
-                        <div class="form-group">
-                            <label for="addUserStatus" class="form-label">Account Status</label>
-                            <select id="addUserStatus" name="status" class="form-input">
-                                <option value="Active">Active</option>
-                                <option value="Inactive">Inactive</option>
-                                <option value="Pending">Pending</option>
-                                <option value="Suspended">Suspended</option>
+                                <option value="default">Default</option>
+                                <option value="toolkeeper">Toolkeeper</option>
+                                <option value="admin">Admin</option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
### Summary  
This PR updates the user management flow to allow admins to create users directly with assigned roles while keeping signup and create_user logic consistent.

### Changes  
- **Model**  
  - Refactored `createUser` to be used both for regular signup and admin `create_user`.  
  - Added `role` parameter support (`DEFAULT`, `TOOLKEEPER`, `ADMIN`).  

- **Controller**  
  - Unified handling for signup and admin user creation.  
  - Applied conditional validation (skip confirm password for admin-created users).  
  - Normalized role assignment to uppercase values.  
  - Implemented proper redirection based on context (signup vs. admin creation).  

- **View / Modal**  
  - Updated **Add User Modal** to submit directly to the controller instead of JS (for consistency with signup).  
  - Added role selection dropdown for admin to assign user roles.  
  - Fixed form attributes for consistency 

- **Other**  
  - Performed basic testing on signup and admin create_user flow.  
  - Ensured transactions and rollback on failure.  
  - Success message and redirection now properly reflect whether the user signed up or was created by an admin.  

### Notes  
- Admin-created users skip password confirmation.  
- Regular signups still require confirmation and automatically log the user in.  
- Toolkeeper users are redirected to **record_output**, while default users go to **dashboard_applicator**.  
