### PR TITLE
fix(auth): prevent overwriting session data on admin user creation

### DIFF
--- a/app/controllers/sign_up.php
+++ b/app/controllers/sign_up.php
@@ -78,16 +78,20 @@ if (is_array($result)) {
         session_start();
     }
     
-    $_SESSION['user_id'] = $result['user_id'];
-    $_SESSION['username'] = $result['username'];
-    $_SESSION['first_name'] = $result['first_name'];
-    $_SESSION['user_type'] = $result['user_type'];
     $pdo->commit();
     if (isset($_POST['admin_create_user'])) {
         jsAlertRedirect("User created successfully.", $redirect_url);
     } elseif ($user_type == 'TOOLKEEPER') {
+        $_SESSION['user_id'] = $result['user_id'];
+        $_SESSION['username'] = $result['username'];
+        $_SESSION['first_name'] = $result['first_name'];
+        $_SESSION['user_type'] = $result['user_type'];
         header("Location: ../views/record_output.php");
     } else {
+        $_SESSION['user_id'] = $result['user_id'];
+        $_SESSION['username'] = $result['username'];
+        $_SESSION['first_name'] = $result['first_name'];
+        $_SESSION['user_type'] = $result['user_type'];
         header("Location: ../views/dashboard_applicator.php");
     }
     exit();


### PR DESCRIPTION
### Summary
This PR fixes an issue where the currently logged-in admin’s session data was being overwritten when creating a new user through the **admin create user** action.

### Changes
- Ensured that session variables (`user_id`, `username`, `first_name`, `user_type`) are **not updated** when an admin creates a new user.
- Only update session data for non-admin login/registration flows (e.g., TOOLKEEPER or DEFAULT user login).

### Impact
- Prevents accidental session override for admins.
- Keeps admin logged in correctly after creating users.
- Ensures consistent behavior across different user creation and login scenarios.
