### PR TITLE
fix (edit-part-value): prevent function redeclaration by separating machine and applicator logic

### DIFF
--- a/app/controllers/undo_reset_applicator.php
+++ b/app/controllers/undo_reset_applicator.php
@@ -78,7 +78,7 @@ try {
     }
 
     // Update applicator monitoring table to revert an applicator part's output to value before reset
-    $result = editPartOutputValue($applicator_id, $part_name, $previous_output);
+    $result = editApplicatorPartOutputValue($applicator_id, $part_name, $previous_output);
     if (is_string($result)) {
         $pdo->rollBack();
         jsAlertRedirect($result, $redirect_url); // error message

--- a/app/controllers/undo_reset_machine.php
+++ b/app/controllers/undo_reset_machine.php
@@ -78,7 +78,7 @@ try {
     }
 
     // Update machine monitoring table to revert a machine part's output to value before reset
-    $result = editPartOutputValue($machine_id, $part_name, $previous_output);
+    $result = editMachinePartOutputValue($machine_id, $part_name, $previous_output);
     if (is_string($result)) {
         $pdo->rollBack();
         jsAlertRedirect($result, $redirect_url); // error message

--- a/app/models/update_monitor_applicator.php
+++ b/app/models/update_monitor_applicator.php
@@ -246,7 +246,7 @@ function resetApplicatorPartOutput($applicator_id, $part_name) {
 }
 
 
-function editPartOutputValue($applicator_id, $part_name, $value) {
+function editApplicatorPartOutputValue($applicator_id, $part_name, $value) {
     /*
         Reverts the output value for a specific part of an applicator.
         Supports both defined columns and custom JSON parts.
@@ -300,8 +300,8 @@ function editPartOutputValue($applicator_id, $part_name, $value) {
             return true;
 
         } catch (PDOException $e) {
-            error_log("Database Error in editPartOutputValue (defined): " . $e->getMessage());
-            return "Database error in editPartOutputValue (defined): " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+            error_log("Database Error in editApplicatorPartOutputValue (defined): " . $e->getMessage());
+            return "Database error in editApplicatorPartOutputValue (defined): " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
         }
     }
 
@@ -344,8 +344,8 @@ function editPartOutputValue($applicator_id, $part_name, $value) {
             return true;
 
         } catch (PDOException $e) {
-            error_log("Database Error in editPartOutputValue (custom): " . $e->getMessage());
-            return "Database error in editPartOutputValue (custom): " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+            error_log("Database Error in editApplicatorPartOutputValue (custom): " . $e->getMessage());
+            return "Database error in editApplicatorPartOutputValue (custom): " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
         }
     }
 

--- a/app/models/update_monitor_machine.php
+++ b/app/models/update_monitor_machine.php
@@ -196,7 +196,7 @@ function resetMachinePartOutput($machine_id, $part_name) {
 }
 
 
-function editPartOutputValue($machine_id, $part_name, $value) {
+function editMachinePartOutputValue($machine_id, $part_name, $value) {
     /*
         Reverts a machine part output to a given value.
         Supports both standard columns and custom JSON parts.
@@ -244,8 +244,8 @@ function editPartOutputValue($machine_id, $part_name, $value) {
             return true;
 
         } catch (PDOException $e) {
-            error_log("Database Error in editPartOutputValue (defined): " . $e->getMessage());
-            return "Database error in editPartOutputValue (defined): " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+            error_log("Database Error in editPaeditMachinePartOutputValuertOutputValue (defined): " . $e->getMessage());
+            return "Database error in editMachinePartOutputValue (defined): " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
         }
     }
 
@@ -288,8 +288,8 @@ function editPartOutputValue($machine_id, $part_name, $value) {
             return true;
 
         } catch (PDOException $e) {
-            error_log("Database Error in editPartOutputValue (custom): " . $e->getMessage());
-            return "Database error in editPartOutputValue (custom): " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+            error_log("Database Error in editMachinePartOutputValue (custom): " . $e->getMessage());
+            return "Database error in editMachinePartOutputValue (custom): " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
         }
     }
 


### PR DESCRIPTION
### Summary
This PR resolves a fatal error caused by redeclaring the `editPartOutputValue()` function in both `update_monitor_applicator.php` and `update_monitor_machine.php`.  

### Details
- Differentiated the function for **machine** and **applicator** logic.  
- Ensured both files now use uniquely named functions to avoid conflicts.  
- Prevents PHP fatal errors due to duplicate function declarations.  
