### PR TITLE
feature(applicator/custom-part-modal): backend for adding and displaying custom parts

### DIFF
--- a/app/controllers/add_custom_part.php
+++ b/app/controllers/add_custom_part.php
@@ -17,7 +17,7 @@ require_once '../includes/db.php';
 include_once '../models/create_custom_part.php';
 
 // Redirect url
-$redirect_url = "../views/add_entry.php";
+$redirect_url = "../views/dashboard_applicator.php";
 
 // Check if the request method is POST
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
@@ -38,14 +38,16 @@ if (empty($type) || empty($name)) {
     exit;
 }
 
-if ($type !== "APPLICATOR" || $name !== "MACHINE") {
+// Check for equipment type
+$valid_types = ["APPLICATOR", "MACHINE", "PRESS"];
+if (!in_array($type, $valid_types, true)) {
     jsAlertRedirect("Invalid equipment type.", $redirect_url);
     exit;
-}   
+}
 
 // 3. Database operation
 $pdo->beginTransaction();
-$result = createCustomPart($type, $name);
+$result = createCustomPart((int) $_SESSION['user_id'], $type, $name);
 
 // Check if custom part creation was successful
 if ($result === true) {

--- a/app/models/create_custom_part.php
+++ b/app/models/create_custom_part.php
@@ -7,14 +7,14 @@
 // Include the database connection
 require_once __DIR__ . '/../includes/db.php';
 
-function createCustomPart($type, $name) {
+function createCustomPart($user_id, $type, $name) {
     /*
         Function to create a new custom part in the database.
 
         Args:
         - $type: Type of the custom part.
         - $name: Name of the custom part.
-                    
+        
         Returns:
         - true on successful operation.
         - string containing error message.
@@ -25,11 +25,12 @@ function createCustomPart($type, $name) {
     try {
         // Prepare SQL insert query
         $stmt = $pdo->prepare("
-            INSERT INTO custom_parts (type, name)
-            VALUES (:type, :name)
+            INSERT INTO custom_part_definitions (equipment_type, part_name, created_by)
+            VALUES (:type, :name, :user_id)
         ");
 
         // Bind parameters
+        $stmt->bindParam(':user_id', $user_id, PDO::PARAM_INT);
         $stmt->bindParam(':type', $type, PDO::PARAM_STR);
         $stmt->bindParam(':name', $name, PDO::PARAM_STR);
 

--- a/app/views/dashboard_applicator.php
+++ b/app/views/dashboard_applicator.php
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HEPC - Applicator Dashboard</title>
-    <!--link rel="stylesheet" href="../../public/assets/css/dashboard_applicator.css">
+    <link rel="stylesheet" href="../../public/assets/css/dashboard_applicator.css">
     <link rel="stylesheet" href="/SOMS/public/assets/css/components/header.css">
     <link rel="stylesheet" href="/SOMS/public/assets/css/components/modal.css">
-    <link rel="stylesheet" href="/SOMS/public/assets/css/components/tables.css"-->
+    <link rel="stylesheet" href="/SOMS/public/assets/css/components/tables.css">
 </head>
 <body>
     <?php 


### PR DESCRIPTION
### Summary
Implemented backend support for managing applicator custom parts via modal.

### Changes
- Added backend logic to insert new custom parts into the database with proper validation.
- Integrated session-based `user_id` handling to fix foreign key constraint violations.
- Populated the custom parts table in the modal with existing entries from the database.

### Notes
- Fixes issue with missing `user_id` in insert queries.
- Completes the flow from adding → saving → displaying custom parts.
- Edit/delete implementation to follow in succeeding PR
