### PR TITLE
feat(backend): implement delete logic for custom parts with transaction handling

### DIFF
--- a/app/controllers/delete_custom_part.php
+++ b/app/controllers/delete_custom_part.php
@@ -1,0 +1,55 @@
+<?php
+/*
+    This script handles the deletion of a custom part from the database.
+    It retrieves the part ID, sanitizes it, and deletes the corresponding record.
+*/
+
+// Start session and check if user is logged in
+session_start(); 
+if (!isset($_SESSION['user_id'])) {
+    header("Location: ../views/dashboard_applicator.php");
+    exit();
+}
+
+// Include necessary files
+require_once '../includes/js_alert.php';
+require_once '../includes/db.php'; 
+include_once '../models/delete_custom_part.php';
+
+// Redirect url
+$redirect_url = "../views/dashboard_applicator.php";
+
+// Check if the request method is POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    jsAlertRedirect("Invalid request method.", $redirect_url);
+    exit;
+}
+
+
+// 1. Sanitize input
+$part_id = isset($_POST['part_id']) ? intval($_POST['part_id']) : null;
+
+// 2. Validation
+if (empty($part_id)) {
+    jsAlertRedirect("Invalid part ID.", $redirect_url);
+    exit;
+}
+
+// 3. Database operation
+$pdo->beginTransaction();
+$result = deleteCustomPart($part_id);
+
+// Check if custom part deletion was successful
+if ($result === true) {
+    $pdo->commit();
+    jsAlertRedirect("Custom part deleted successfully!", $redirect_url);
+    exit;
+} elseif (is_string($result)) {
+    $pdo->rollBack(); // Rollback transaction in case of error
+    jsAlertRedirect($result, $redirect_url);
+    exit;
+} else {
+    $pdo->rollBack();
+    jsAlertRedirect("Failed to delete custom part. Please try again.", $redirect_url);
+    exit;
+}

--- a/app/models/delete_custom_part.php
+++ b/app/models/delete_custom_part.php
@@ -1,0 +1,38 @@
+<?php
+/*
+    This file contains a function for deleting (hard DELETE-ing) a custom part row 
+    in the custom_parts table. 
+    It is used in the custom parts listing with pagination (e.g., infinite scroll).
+*/
+
+// Include the database connection
+require_once __DIR__ . '/../includes/db.php'; 
+
+function deleteCustomPart($part_id) {
+    /*
+        Delete a custom part from the database.
+
+        Args:
+        - $part_id: ID of the custom part to delete
+
+        Returns:
+        - true on success
+        - string containing error message on failure
+    */
+    global $pdo;
+
+    try {
+        // Prepare the SQL statement
+        $stmt = $pdo->prepare("DELETE FROM custom_part_definitions WHERE part_id = :part_id");
+        $stmt->bindParam(':part_id', $part_id, PDO::PARAM_INT);
+
+        // Execute the statement
+        $stmt->execute();
+
+        return true;
+    } catch (PDOException $e) {
+        // Log error
+        error_log("Database Error on deleteCustomPart: " . $e->getMessage());
+        return "Database Error on deleteCustomPart: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/views/dashboard_applicator.php
+++ b/app/views/dashboard_applicator.php
@@ -297,7 +297,7 @@
                                             data-part-name="<?= htmlspecialchars($partNameTitle, ENT_QUOTES) ?>">
                                         Edit
                                     </button>
-                                    <button class="btn btn-delete" onclick="confirmDeletePart(<?= htmlspecialchars($part['part_id']) ?>)">Delete</button>
+                                    <button class="btn btn-delete" data-part-id="<?= htmlspecialchars($part['part_id']) ?>" >Delete</button>
                                 </td>
                             </tr>
                             <?php endforeach; ?>

--- a/public/assets/js/dashboard_applicator.js
+++ b/public/assets/js/dashboard_applicator.js
@@ -107,6 +107,35 @@ function closeEditCustomPartModal() {
     document.getElementById('editCustomPartModalDashboardApplicator').style.display = 'none';
 }
 
+// Listen for clicks on delete buttons in the custom parts table
+document.addEventListener('click', function(event) {
+    if (event.target.classList.contains('btn-delete')) {
+        const partId = event.target.getAttribute('data-part-id');
+        confirmDeleteCustomPart(partId);
+    }
+});
+
+// Delete confirmation
+function confirmDeleteCustomPart(partId) {
+    if (confirm("Are you sure you want to delete this custom part? This action CANNOT be undone!")) {
+        // Create a form dynamically
+        const form = document.createElement("form");
+        form.method = "POST";
+        form.action = "../controllers/delete_custom_part.php";
+
+        // Add hidden input for part_id
+        const input = document.createElement("input");
+        input.type = "hidden";
+        input.name = "part_id";
+        input.value = partId;
+
+        form.appendChild(input);
+        document.body.appendChild(form);
+
+        form.submit();
+    }
+}
+
 // Open the parts inventory modal
 function openPartsInventoryModal() {
     document.getElementById('partsInventoryModalDashboardApplicator').style.display = 'block';


### PR DESCRIPTION
### Summary
This PR adds backend functionality for deleting custom parts securely using POST requests and transaction handling.

### Changes
- Implemented delete button with JS confirmation modal and dynamic POST form submission
- Added `delete_custom_part.php` controller to handle requests
- Integrated transaction handling with commit on success and rollback on failure
- Created `deleteCustomPart` model function to execute hard delete on `custom_part_definitions` table
- Added proper error handling and user feedback via `jsAlertRedirect`