### PR TITLE
feat(frontend): display custom machine parts in table with actions

### DIFF
--- a/app/views/dashboard_machine.php
+++ b/app/views/dashboard_machine.php
@@ -353,6 +353,38 @@
         </div>
     </div>
 
+    <!-- Parts Inventory Modal -->
+    <!-- Data Table -->
+    <div class="table-container">
+        <table class="data-table" id="partsTable">
+            <thead>
+                <tr>
+                    <th>Part Name</th>
+                    <th>Created At</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody id="tableBody">
+                <?php foreach ($custom_machine_parts as $part): ?>
+                <!-- Wire Crimper -->
+                <tr>
+                    <td><?= htmlspecialchars(ucwords(str_replace('_', ' ', $part['part_name']))) ?></td>
+                    <td><?= htmlspecialchars(date('Y-m-d', strtotime($part['created_at']))) ?></td>
+                    <td>
+                        <?php $partNameTitle = ucwords(str_replace('_', ' ', strtolower($part['part_name']))); ?>
+                        <button class="btn btn-edit" 
+                                data-part-id="<?= htmlspecialchars($part['part_id']) ?>" 
+                                data-part-name="<?= htmlspecialchars($partNameTitle, ENT_QUOTES) ?>">
+                            Edit
+                        </button>
+                        <button class="btn btn-delete" data-part-id="<?= htmlspecialchars($part['part_id']) ?>" >Delete</button>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>    
+        </table>
+    </div>
+
     <!-- Reset Machine Modal -->
     <div id="resetModalDashboardMachine" class="modal-overlay">
         <div class="modal modal-reset">


### PR DESCRIPTION
### Summary
This PR introduces the frontend implementation for displaying custom machine parts in a table format, with proper formatting and action buttons.

### Changes
- Added table layout (`partsTable`) to display custom machine parts
- Displayed `part_name` in Title Case instead of snake_case
- Formatted `created_at` to `YYYY-MM-DD` for consistency
- Added **Edit** button with data attributes (`part_id`, `part_name`)
- Added **Delete** button with `part_id` binding
- Ensured HTML escaping (`htmlspecialchars`) for security

### Note
This improves the usability of the machine parts inventory modal by showing data in a clean, human-readable format with direct edit/delete options.
