### PR TITLE
feat(machine): enable deletion of custom parts in dashboard

### DIFF
--- a/app/controllers/delete_custom_part.php
+++ b/app/controllers/delete_custom_part.php
@@ -18,6 +18,9 @@ include_once '../models/delete_custom_part.php';
 
 // Redirect url
 $redirect_url = "../views/dashboard_applicator.php";
+if (strtoupper(trim($_POST['equipment_type'])) === "MACHINE") {
+    $redirect_url = "../views/dashboard_machine.php";
+}
 
 // Check if the request method is POST
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {

--- a/app/views/dashboard_machine.php
+++ b/app/views/dashboard_machine.php
@@ -377,7 +377,11 @@
                                 data-part-name="<?= htmlspecialchars($partNameTitle, ENT_QUOTES) ?>">
                             Edit
                         </button>
-                        <button class="btn btn-delete" data-part-id="<?= htmlspecialchars($part['part_id']) ?>" >Delete</button>
+                        <button class="btn btn-delete" 
+                                data-part-id="<?= htmlspecialchars($part['part_id']) ?>" 
+                                data-part-type="MACHINE">
+                            Delete
+                        </button>
                     </td>
                 </tr>
                 <?php endforeach; ?>

--- a/public/assets/js/dashboard_machine.js
+++ b/public/assets/js/dashboard_machine.js
@@ -49,6 +49,7 @@ function closeMachineModal() {
     modal.style.display = 'none';
 }
 
+// Listen for clicks on edit buttons in the custom parts table
 document.addEventListener('click', function(event) {
     const btn = event.target.closest('.btn-edit');
     if (btn) {
@@ -58,6 +59,7 @@ document.addEventListener('click', function(event) {
     }
 });
 
+// Open the edit custom part modal
 function openEditCustomPartModal(partId, partName) {
     const modal = document.getElementById('editCustomPartModalDashboardMachine');
     modal.style.display = 'block';
@@ -65,16 +67,48 @@ function openEditCustomPartModal(partId, partName) {
     document.getElementById('edit_part_name').value = partName;
 }
 
+// Close the edit custom part modal
 function closeEditCustomPartModal() {
     document.getElementById('editCustomPartModalDashboardMachine').style.display = 'none';
 }
 
-window.onclick = function(event) {
-    const modal = document.getElementById('editCustomPartModalDashboardMachine');
-    if (event.target === modal) {
-        modal.style.display = 'none';
+
+// Listen for clicks on delete buttons in the custom parts table
+document.addEventListener('click', function(event) {
+    if (event.target.classList.contains('btn-delete')) {
+        const partId = event.target.getAttribute('data-part-id')
+        const partType = event.target.getAttribute('data-part-type')
+        confirmDeleteCustomPart(partId, partType);
     }
-};
+});
+
+// Delete confirmation
+function confirmDeleteCustomPart(partId, type) {
+    if (confirm("Are you sure you want to delete this custom part? This action CANNOT be undone!")) {
+        // Create a form dynamically
+        const form = document.createElement("form");
+        form.method = "POST";
+        form.action = "../controllers/delete_custom_part.php";
+
+        // Add hidden input for part_id
+        const input = document.createElement("input");
+        input.type = "hidden";
+        input.name = "part_id";
+        input.value = partId;
+
+        // Add hidden input for equipment type
+        const inputType = document.createElement("input");
+        inputType.type = "hidden";
+        inputType.name = "equipment_type";
+        inputType.value = type;
+
+        form.appendChild(input);
+        form.appendChild(inputType);
+        document.body.appendChild(form);
+
+        form.submit();
+    }
+}
 
 
 // Initialize event listeners when the DOM is fully loaded


### PR DESCRIPTION
### Summary
This PR introduces the ability to **delete custom parts** from the **machine dashboard**, extending functionality that already exists for applicators.

### Changes
- Added **Delete** button for machine custom parts with `data-part-type="MACHINE"`.
- Implemented JS confirmation prompt before submitting deletion.
- Dynamically created hidden form inputs (`part_id` and `equipment_type`) to submit POST requests securely.
- Reused existing `delete_custom_part.php` controller.
- Updated redirect logic:
  - Requests from machine dashboard now return to `dashboard_machine.php`.
  - Applicator requests remain unchanged.

### Notes
- Ensures consistent flow between **edit** and **delete** actions across dashboards.
- Maintains single controller for maintainability.
- Prevents accidental deletions with confirmation modal.