### PR TITLE
feat(custom-parts): enable deletion of machine and applicator parts

### DIFF
--- a/app/views/dashboard_applicator.php
+++ b/app/views/dashboard_applicator.php
@@ -439,7 +439,11 @@
                                             data-part-name="<?= htmlspecialchars($partNameTitle, ENT_QUOTES) ?>">
                                         Edit
                                     </button>
-                                    <button class="btn btn-delete" data-part-id="<?= htmlspecialchars($part['part_id']) ?>" >Delete</button>
+                                    <button class="btn btn-delete" 
+                                            data-part-id="<?= htmlspecialchars($part['part_id']) ?>" 
+                                            data-part-type="MACHINE">
+                                        Delete
+                                    </button>
                                 </td>
                             </tr>
                             <?php endforeach; ?>

--- a/public/assets/js/dashboard_applicator.js
+++ b/public/assets/js/dashboard_applicator.js
@@ -111,12 +111,13 @@ function closeEditCustomPartModal() {
 document.addEventListener('click', function(event) {
     if (event.target.classList.contains('btn-delete')) {
         const partId = event.target.getAttribute('data-part-id');
-        confirmDeleteCustomPart(partId);
+        const partType = event.target.getAttribute('data-part-type');
+        confirmDeleteCustomPart(partId, partType);
     }
 });
 
 // Delete confirmation
-function confirmDeleteCustomPart(partId) {
+function confirmDeleteCustomPart(partId, type) {
     if (confirm("Are you sure you want to delete this custom part? This action CANNOT be undone!")) {
         // Create a form dynamically
         const form = document.createElement("form");
@@ -129,7 +130,14 @@ function confirmDeleteCustomPart(partId) {
         input.name = "part_id";
         input.value = partId;
 
+        // Add hidden input for equipment type
+        const inputType = document.createElement("input");
+        inputType.type = "hidden";
+        inputType.name = "equipment_type";
+        inputType.value = type;
+
         form.appendChild(input);
+        form.appendChild(inputType);
         document.body.appendChild(form);
 
         form.submit();

--- a/public/assets/js/dashboard_machine.js
+++ b/public/assets/js/dashboard_machine.js
@@ -76,8 +76,8 @@ function closeEditCustomPartModal() {
 // Listen for clicks on delete buttons in the custom parts table
 document.addEventListener('click', function(event) {
     if (event.target.classList.contains('btn-delete')) {
-        const partId = event.target.getAttribute('data-part-id')
-        const partType = event.target.getAttribute('data-part-type')
+        const partId = event.target.getAttribute('data-part-id');
+        const partType = event.target.getAttribute('data-part-type');
         confirmDeleteCustomPart(partId, partType);
     }
 });


### PR DESCRIPTION
### Summary
This PR adds the ability to **delete custom parts** from both the **machine** and **applicator** dashboards using a unified flow.

### Changes
- Added **Delete** button to both dashboards with `data-part-id` and `data-part-type`.
- Implemented JS delete confirmation (`confirmDeleteCustomPart`) with dynamic hidden form creation.
- Passed `part_id` and `equipment_type` to the backend for request handling.
- Reused `delete_custom_part.php` controller with redirect logic:
  - Machine → `dashboard_machine.php`
  - Applicator → `dashboard_applicator.php`

### Notes
- Keeps deletion logic **consistent and reusable** across equipment types.
- Provides user safety with confirmation prompt before irreversible actions.