### PR TITLE
feat(machine): add hard delete feature for machines and related records

### DIFF
--- a/app/controllers/delete_machine.php
+++ b/app/controllers/delete_machine.php
@@ -1,0 +1,65 @@
+<?php
+/*
+    This script handles the deletion (hard delete) of a machine to the database.
+    This includes removing all associated data and records. 
+    It retrieves form data, sanitizes it, and updates the status in the database.
+*/
+
+// Start session and check if user is logged in
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header("Location: ../views/login.php");
+    exit();
+}
+
+// Include necessary files
+require_once '../includes/js_alert.php';
+require_once '../models/delete_machines.php';
+require_once '../models/delete_record.php';
+
+// Redirect url
+$redirect_url = "../views/dashboard_machine.php";
+
+// Check if the request method is POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    jsAlertRedirect("Invalid request method.", $redirect_url);
+    exit;
+}
+
+// 1. Sanitize input
+$machine_id = isset($_POST['machine_id']) ? (int)trim($_POST['machine_id']) : null;
+
+// 2. Validation
+if (empty($machine_id)) {
+    jsAlertRedirect("Machine ID is required.", $redirect_url);
+    exit;
+}
+
+// 3. Database operation
+try {
+    $pdo->beginTransaction();
+
+    // Delete machine
+    $deleteMachine = deleteMachine($machine_id);
+    if (is_string($deleteMachine)) {
+        throw new Exception($deleteMachine);
+    }
+
+    // Delete machine outputs
+    $deleteMachineOutput = deleteOutputByMachineID($machine_id);
+    if (is_string($deleteMachineOutput)) {
+        throw new Exception($deleteMachineOutput);
+    }
+
+    // If everything is successful, commit
+    $pdo->commit();
+    jsAlertRedirect("Machine and records disabled successfully.", $redirect_url);
+
+} catch (Exception $e) {
+    // Rollback transaction in case of error
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    jsAlertRedirect($e->getMessage(), $redirect_url);
+    exit;
+}

--- a/app/controllers/disable_machine.php
+++ b/app/controllers/disable_machine.php
@@ -40,7 +40,7 @@ $result = disableMachine($machine_id);
 // Check if machine deletion was successful
 if ($result === true) {
     $pdo->commit();
-    jsAlertRedirect("Machine deleted successfully!", $redirect_url);
+    jsAlertRedirect("Machine disabled successfully!", $redirect_url);
     exit;
 } elseif (is_string($result)) {
     $pdo->rollBack(); // Rollback transaction in case of error
@@ -48,6 +48,6 @@ if ($result === true) {
     exit;
 } else {
     $pdo->rollBack();
-    jsAlertRedirect("Failed to delete machine. Please try again.", $redirect_url);
+    jsAlertRedirect("Failed to disable machine. Please try again.", $redirect_url);
     exit;
 }

--- a/app/models/delete_machines.php
+++ b/app/models/delete_machines.php
@@ -36,3 +36,44 @@ function disableMachine($machine_id): bool {
         return "Database Error on disableMachine: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
     }
 }
+
+
+function deleteMachine($machine_id): bool|string {
+    /*
+        Delete a machine from the database.
+
+        Args:
+        - $machine_id: ID of the machine to delete
+
+        Returns:
+        - true on success
+        - string containing error message on failure
+    */
+    global $pdo;
+
+    // Basic validation
+    if (!is_numeric($machine_id) || $machine_id <= 0) {
+        return "Invalid machine ID.";
+    }
+
+    try {
+        // Prepare the SQL statement
+        $stmt = $pdo->prepare("DELETE FROM machines WHERE machine_id = :machine_id");
+        $stmt->bindParam(':machine_id', $machine_id, PDO::PARAM_INT);
+
+        // Execute the statement
+        $stmt->execute();
+
+        // Check if any row was deleted
+        if ($stmt->rowCount() === 0) {
+            return "No machine found with the given ID.";
+        }
+
+        return true;
+    
+    } catch (PDOException $e) {
+        // Log error
+        error_log("Database Error on deleteMachine: " . $e->getMessage());
+        return "Database error while deleting machine: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/models/delete_record.php
+++ b/app/models/delete_record.php
@@ -36,6 +36,37 @@ function disableRecord($record_id): bool|string {
 }
 
 
+function deleteOutputByMachineID(int $machine_id): bool|string {
+    /*
+        Function to delete all records in the database for a specific machine.
+
+        Args:
+        - $machine_id: ID of the machine whose records should be deleted
+
+        Returns:
+        - true on success
+        - string containing error message on failure
+    */
+    global $pdo;
+
+    try {
+        // Prepare the SQL statement
+        $stmt = $pdo->prepare("DELETE FROM records WHERE machine_id = :machine_id");
+        $stmt->bindParam(':machine_id', $machine_id, PDO::PARAM_INT);
+
+        // Execute the statement
+        $stmt->execute();
+
+        return true;
+
+    } catch (PDOException $e) {
+        // Log error
+        error_log("Database Error on deleteOutputByMachineID: " . $e->getMessage());
+        return "Database error while deleting records: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}
+
+
 function disableRecordEncodedLaterThan($timestamp): bool|string {
     /*
         Function to disable (soft delete) all records encoded later than a timestamp in the database.

--- a/app/views/dashboard_machine.php
+++ b/app/views/dashboard_machine.php
@@ -281,7 +281,11 @@
                                                     data-machine-id="<?= htmlspecialchars($machine['machine_id']) ?>">
                                                 Restore
                                             </button>
-                                            <button class="delete-btn" data-id="<?php echo $machine['machine_id']; ?>">Delete</button>
+                                            <button id="delete-machine-<?= htmlspecialchars($machine['machine_id']) ?>"
+                                                    class="delete-machine-btn"
+                                                    data-machine-id="<?= htmlspecialchars($machine['machine_id']) ?>">
+                                                Delete
+                                            </button>
                                         </td>
                                         <td><?php echo htmlspecialchars($machine['control_no']); ?></td>
                                         <td><?php echo htmlspecialchars($machine['model']); ?></td>

--- a/public/assets/js/dashboard_machine.js
+++ b/public/assets/js/dashboard_machine.js
@@ -139,6 +139,35 @@ function confirmRestoreCustomPart(machineId) {
     }
 }
 
+// Listen for clicks only on the delete machine button
+document.addEventListener('click', function(event) {
+    if (event.target.classList.contains('delete-machine-btn')) {
+        const machineId = event.target.dataset.machineId;
+        confirmDeleteMachine(machineId);
+    }
+});
+
+// Delete confirmation
+function confirmDeleteMachine(machineId) {
+    if (confirm("This action will PERMANENTLY DELETE all records pertaining to this machine - including outputs from this machine! Are you sure you want to delete this machine?")) {
+        // Create a form dynamically
+        const form = document.createElement("form");
+        form.method = "POST";
+        form.action = "../controllers/delete_machine.php";
+        
+        // Add hidden input for machine_id
+        const input = document.createElement("input");
+        input.type = "hidden";
+        input.name = "machine_id";
+        input.value = machineId;
+
+        form.appendChild(input);
+        document.body.appendChild(form);
+
+        form.submit();
+    }
+}
+
 // Initialize event listeners when the DOM is fully loaded
 document.addEventListener('DOMContentLoaded', function () {
     console.log('DOM loaded, initializing dashboard machine...'); // Debug log


### PR DESCRIPTION
## Summary
This PR introduces the **hard delete feature** for machines.  
When triggered, the system will permanently delete a machine and all associated records/outputs from the database.

## Changes
- Added frontend confirmation dialog before deletion.
- Implemented dynamic form submission with `machine_id` passed via hidden input.
- Created controller `delete_machine.php` to handle hard delete requests.
- Integrated database operations with transaction handling:
  - `deleteMachine($machine_id)`
  - `deleteOutputByMachineID($machine_id)`
- Rolled back transactions and displayed alerts if any step fails.
- Redirected users back to the dashboard with proper success/error messages.

## Notes
- This is a **hard delete** (data is permanently removed).
- Includes validation for `machine_id` and request method.
- Ensures DB consistency by wrapping operations in a transaction.
