### PR TITLE
feat(applicators): implement disabled applicators table with action buttons

### DIFF
--- a/app/models/read_applicators.php
+++ b/app/models/read_applicators.php
@@ -38,6 +38,41 @@ function getApplicators(PDO $pdo, int $limit = 10, int $offset = 0): array {
 }
 
 
+function getDisabledApplicators(int $limit = 10, int $offset = 0): array {
+    /*
+        Function to fetch a list of disabled applicators from the database with pagination.
+        It prepares and executes a SELECT query that fetches applicators ordered by most recent,
+        and returns them as an associative array.
+
+        Args:
+        - $limit: Maximum number of rows to fetch (default is 10).
+        - $offset: Number of rows to skip (default is 0), used for pagination.
+
+        Returns:
+        - Array of applicators (associative arrays) on success.
+    */
+
+    global $pdo;
+
+    // Prepare the SQL statement with placeholders for limit and offset
+    $stmt = $pdo->prepare("
+        SELECT applicator_id, hp_no, description, terminal_maker, applicator_maker, last_encoded
+        FROM applicators
+        WHERE is_active = 0
+        ORDER BY applicator_id DESC 
+        LIMIT :limit OFFSET :offset
+    ");
+
+    // Bind pagination parameters securely
+    $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+
+    // Execute the query and return the results
+    $stmt->execute();
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+
 function applicatorExists($hp_no){
     /*
         Function to check if applicator exists.

--- a/app/views/dashboard_applicator.php
+++ b/app/views/dashboard_applicator.php
@@ -4,11 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HEPC - Applicator Dashboard</title>
-    <link rel="stylesheet" href="../../public/assets/css/base/base.css">
+    <!-- link rel="stylesheet" href="../../public/assets/css/base/base.css">
     <link rel="stylesheet" href="../../public/assets/css/dashboard_applicator.css">
     <link rel="stylesheet" href="/SOMS/public/assets/css/components/header.css">
     <link rel="stylesheet" href="/SOMS/public/assets/css/components/modal.css">
-    <link rel="stylesheet" href="/SOMS/public/assets/css/components/tables.css">
+    <link rel="stylesheet" href="/SOMS/public/assets/css/components/tables.css" -->
 </head>
 <body>
     <?php 
@@ -65,7 +65,11 @@
     // Get parts priority data
     $parts_ordered = getPartsOrderedByOutput($part_names_array);
     $top_3_parts = array_slice($parts_ordered, 0, 3);
-    ?>
+
+        // Get disabled applicators
+        require_once __DIR__ . '/../models/read_applicators.php';
+        $disabled_applicators = getDisabledApplicators(10, 0);
+        ?>
 
     <div class="container">
         <!-- Main Content -->
@@ -277,25 +281,43 @@
                                 <table class="data-table">
                                     <thead>
                                         <tr>
-                                            <th>Part Name</th>
+                                            <th>Actions</th>
+                                            <th>HP Number</th>
+                                            <th>Description</th>
+                                            <th>Terminal Maker</th>
+                                            <th>Applicator Maker</th>
+                                            <th>Last Encoded</th>
                                         </tr>
                                     </thead>
                                     <tbody>
+                                        <?php foreach ($disabled_applicators as $applicator): ?>
                                         <tr>
-                                            <td>Custom Wire Crimper Pro</td>
+                                            <td>
+                                                <button id="restore-applicator-<?= htmlspecialchars($applicator['applicator_id']) ?>"
+                                                        class="restore-btn"
+                                                        data-applicator-id="<?= htmlspecialchars($applicator['applicator_id']) ?>">
+                                                    Restore
+                                                </button>
+                                                <button id="delete-applicator-<?= htmlspecialchars($applicator['applicator_id']) ?>"
+                                                        class="delete-applicator-btn"
+                                                        data-applicator-id="<?= htmlspecialchars($applicator['applicator_id']) ?>">
+                                                    Delete
+                                                </button>
+                                            </td>
+                                            <td><?php echo htmlspecialchars($applicator['hp_no']); ?></td>
+                                            <td><?php echo htmlspecialchars($applicator['description']); ?></td>
+                                            <td><?php echo htmlspecialchars($applicator['terminal_maker']); ?></td>
+                                            <td><?php echo htmlspecialchars($applicator['applicator_maker']); ?></td>
+                                            <td><?php echo htmlspecialchars($applicator['last_encoded']); ?></td>
                                         </tr>
-                                        <tr>
-                                            <td>Enhanced Cut Blade X1</td>
-                                        </tr>
-                                        <tr>
-                                            <td>Precision Wire Anvil V2</td>
-                                        </tr>
+                                        <?php endforeach; ?>
                                     </tbody>
                                 </table>
                             </div>
                         </div>
                     </div>
-                                    <!-- Table 2: Recently Deleted Machine -->
+
+                    <!-- Table 2: Recently Deleted Machine -->
                     <div class="data-section">
                         <div class="section-header">
                             <div class="section-title">


### PR DESCRIPTION
### Summary
This PR introduces the **Disabled Applicators** section in the dashboard.  
It mirrors the disabled machines feature, allowing users to view applicators that are inactive and manage them.

### Changes
- Added `getDisabledApplicators()` in `read_applicators.php` to fetch inactive applicators with pagination.
- Displayed disabled applicators in a dedicated table with columns:
  - HP Number
  - Description
  - Terminal Maker
  - Applicator Maker
  - Last Encoded
- Added **Restore** and **Delete** action buttons for each applicator row.
- Integrated pagination support via `LIMIT` and `OFFSET` parameters in query.

### Notes
- Restore and delete logic for applicators will be implemented in follow-up PRs.
- Table design is consistent with existing **Disabled Machines** section.
