### PR TITLE
refactor(machine-disable): enhance transaction flow and disable related outputs

### DIFF
--- a/app/models/update_machine_output.php
+++ b/app/models/update_machine_output.php
@@ -83,3 +83,41 @@ function updateMachineOutput($machine_data, $machine_output, $record_id) {
         return "Database error occurred in updateMachineOutput: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
     }
 }
+
+
+function disableMachineOutputs($machine_id) {
+    /*
+        Disable (soft delete) machine outputs in the database.
+        Sets the status of all outputs for a given machine to 'disabled'.
+
+        Args:
+        - $machine_id: int, ID of the machine to disable outputs for
+
+        Returns:
+        - true on successful disable
+        - string containing error message on failure
+    */
+
+    global $pdo;
+
+    try {
+        // Update the status of all outputs for the given machine
+        $stmt = $pdo->prepare("
+            UPDATE machine_outputs
+            SET is_active = 0
+            WHERE machine_id = :machine_id
+        ");
+
+        $stmt->bindParam(':machine_id', $machine_id, PDO::PARAM_INT);
+
+        // Execute the query
+        $stmt->execute();
+
+        return true;
+
+    } catch (PDOException $e) {
+        // Log error and return an error message on failure
+        error_log("Database Error in disableMachineOutputs: " . $e->getMessage());
+        return "Database error occurred when disabling machine outputs: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/models/update_monitor_machine.php
+++ b/app/models/update_monitor_machine.php
@@ -295,3 +295,41 @@ function editMachinePartOutputValue($machine_id, $part_name, $value) {
 
     return "Revert cancelled: invalid part name!";
 }
+
+
+function disableMachineCumulativeOutputs($machine_id) {
+    /*
+        Disable (soft delete) cumulative outputs in the database.
+        Sets the status of all cumulative outputs for a given machine to 'disabled'.
+
+        Args:
+        - $machine_id: int, ID of the machine to disable cumulative outputs for
+
+        Returns:
+        - true on successful disable
+        - string containing error message on failure
+    */
+
+    global $pdo;
+
+    try {
+        // Update the status of all cumulative outputs for the given machine
+        $stmt = $pdo->prepare("
+            UPDATE monitor_machine
+            SET is_active = 0
+            WHERE machine_id = :machine_id
+        ");
+
+        $stmt->bindParam(':machine_id', $machine_id, PDO::PARAM_INT);
+
+        // Execute the query
+        $stmt->execute();
+
+        return true;
+
+    } catch (PDOException $e) {
+        // Log error and return an error message on failure
+        error_log("Database Error in disableMachineCumulativeOutputs: " . $e->getMessage());
+        return "Database error occurred when disabling machine cumulative outputs: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/views/dashboard_machine.php
+++ b/app/views/dashboard_machine.php
@@ -4,13 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HEPC - Machine Dashboard</title>
-    <link rel="stylesheet" href="../../public/assets/css/base/base.css">
+    <!-- link rel="stylesheet" href="../../public/assets/css/base/base.css">
     <link rel="stylesheet" href="../../public/assets/css/dashboard_machine.css">
     <link rel="stylesheet" href="/SOMS/public/assets/css/components/modal.css">
     <link rel="stylesheet" href="/SOMS/public/assets/css/components/header.css">
     <link rel="stylesheet" href="/SOMS/public/assets/css/components/tables.css">
     <link rel="stylesheet" href="/SOMS/public/assets/css/components/buttons.css">
-    <link rel="stylesheet" href="/SOMS/public/assets/css/components/sidebar.css">
+    <link rel="stylesheet" href="/SOMS/public/assets/css/components/sidebar.css" -->
 </head>
 <body>
     <?php


### PR DESCRIPTION
### Summary
This PR refactors the machine disabling process by improving transaction handling and ensuring all related entities are disabled consistently.

### Changes
- Wrapped all disable operations in a `try/catch` block with proper transaction control.
- Added validation for each disable function:
  - If a function returns a string, it throws an exception with that message.
- Expanded the logic so that disabling a machine also:
  - Disables its outputs
  - Disables its cumulative outputs
- Improved error handling:
  - Any error triggers a rollback
  - Error message is surfaced through `jsAlertRedirect`

### Notes
Previously, the logic only disabled the machine itself. Outputs and cumulative outputs were not covered, creating potential inconsistencies.  
This refactor ensures the disable operation is **atomic and reliable**, with clearer failure handling.