### PR TITLE
Refactor: Extend restore-disabled-machine functionality to outputs and monitoring

### DIFF
--- a/app/controllers/restore_machine.php
+++ b/app/controllers/restore_machine.php
@@ -2,23 +2,26 @@
 /*
     This file is the controller file for restoring a disabled machine.
     It retrieves form data, sanitizes it, and updates the database record.
+    - restore machine
+    - restore outputs of the machine
+    - restore cumulative outputs of the machine
 */
 
+// Start session and check if user is logged in
+session_start(); 
+if (!isset($_SESSION['user_id'])) {
+    header("Location: ../views/login.php");
+    exit();
+}
 
-session_start();
-
+// Include necessary files
 require_once '../includes/js_alert.php';
-require_once '../includes/db.php';
 require_once '../models/update_machine.php';
+require_once '../models/update_machine_output.php';
+require_once '../models/update_monitor_machine.php';
 
 // Redirect url
 $redirect_url = "../views/dashboard_machine.php";
-
-// Ensure request method is POST
-if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    jsAlertRedirect("Invalid request method!", $redirect_url);
-    exit;
-}
 
 // Check for credentials 
 if (isset($_SESSION['user_type']) != "ADMIN") {
@@ -26,34 +29,55 @@ if (isset($_SESSION['user_type']) != "ADMIN") {
     exit;
 }
 
-// Get the form data
-$machine_id = isset($_POST['machine_id']) ? trim($_POST['machine_id']) : null;
-
-// Check if fields are empty
-if (empty($machine_id)) {
-    jsAlertRedirect("Missing required fields.", $redirect_url);
+// Check if the request method is POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    jsAlertRedirect("Invalid request method.", $redirect_url);
     exit;
 }
 
+// 1. Sanitize input
+$machine_id = isset($_POST['machine_id']) ? strtoupper(trim($_POST['machine_id'])) : null;
+
+// 2. Validation
+if (empty($machine_id)) {
+    jsAlertRedirect("Machine ID is required.", $redirect_url);
+    exit;
+}
+
+// 3. Database operation
 try {
     $pdo->beginTransaction();
 
-    $result = restoreDisabledMachine($machine_id);
-    if ($result === true) {
+    // restores machine
+    $restoreMachine = restoreDisabledMachine($machine_id);
+    if (is_string($restoreMachine)) {
+        throw new Exception($restoreMachine);
+    }
+
+    // restores outputs of the machine
+    $restoreOutputs = restoreMachineOutputs($machine_id);
+    if (is_string($restoreOutputs)) {
+        throw new Exception($restoreOutputs);
+    }
+
+    // restores cumulative outputs of the machine
+    $restoreCumulativeOutputs = restoreMachineCumulativeOutputs($machine_id);
+    if (is_string($restoreCumulativeOutputs)) {
+        throw new Exception($restoreCumulativeOutputs);
+    }
+
+    // Check if all returned true
+    if ($restoreMachine && $restoreOutputs && $restoreCumulativeOutputs) {
         $pdo->commit();
         jsAlertRedirect("Machine restored successfully!", $redirect_url);
         exit;
-    } elseif (is_string($result)) {
-        $pdo->rollBack();
-        jsAlertRedirect($result, $redirect_url);
-        exit;
     } else {
-        $pdo->rollBack();
-        jsAlertRedirect("Failed to restore machine. Please try again.", $redirect_url);
-        exit;
+        throw new Exception("Failed to restore machine. Please try again.");
     }
-} catch (PDOException $e) {
+
+} catch (Exception $e) {
+    // Rollback on any error
     $pdo->rollBack();
-    jsAlertRedirect("Database transaction failed: " . htmlspecialchars($e->getMessage()), $redirect_url);
+    jsAlertRedirect($e->getMessage(), $redirect_url);
     exit;
 }

--- a/app/models/update_machine_output.php
+++ b/app/models/update_machine_output.php
@@ -121,3 +121,41 @@ function disableMachineOutputs($machine_id) {
         return "Database error occurred when disabling machine outputs: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
     }
 }
+
+
+function restoreMachineOutputs($machine_id) {
+    /*
+        Restore (undo soft delete) machine outputs in the database.
+        Sets the status of all outputs for a given machine to 'enabled'.
+
+        Args:
+        - $machine_id: int, ID of the machine to restore outputs for
+
+        Returns:
+        - true on successful restore
+        - string containing error message on failure
+    */
+
+    global $pdo;
+
+    try {
+        // Update the status of all outputs for the given machine
+        $stmt = $pdo->prepare("
+            UPDATE machine_outputs
+            SET is_active = 1
+            WHERE machine_id = :machine_id
+        ");
+
+        $stmt->bindParam(':machine_id', $machine_id, PDO::PARAM_INT);
+
+        // Execute the query
+        $stmt->execute();
+
+        return true;
+
+    } catch (PDOException $e) {
+        // Log error and return an error message on failure
+        error_log("Database Error in restoreMachineOutputs: " . $e->getMessage());
+        return "Database error occurred when restoring machine outputs: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}

--- a/app/models/update_monitor_machine.php
+++ b/app/models/update_monitor_machine.php
@@ -333,3 +333,41 @@ function disableMachineCumulativeOutputs($machine_id) {
         return "Database error occurred when disabling machine cumulative outputs: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
     }
 }
+
+
+function restoreMachineCumulativeOutputs($machine_id) {
+    /*
+        Restore (undo soft delete) cumulative outputs in the database.
+        Sets the status of all cumulative outputs for a given machine to 'enabled'.
+
+        Args:
+        - $machine_id: int, ID of the machine to restore cumulative outputs for
+
+        Returns:
+        - true on successful restore
+        - string containing error message on failure
+    */
+
+    global $pdo;
+
+    try {
+        // Update the status of all cumulative outputs for the given machine
+        $stmt = $pdo->prepare("
+            UPDATE monitor_machine
+            SET is_active = 1
+            WHERE machine_id = :machine_id
+        ");
+
+        $stmt->bindParam(':machine_id', $machine_id, PDO::PARAM_INT);
+
+        // Execute the query
+        $stmt->execute();
+
+        return true;
+
+    } catch (PDOException $e) {
+        // Log error and return an error message on failure
+        error_log("Database Error in restoreMachineCumulativeOutputs: " . $e->getMessage());
+        return "Database error occurred when restoring machine cumulative outputs: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
+    }
+}


### PR DESCRIPTION
### Summary
Extended the restore-disabled-machine functionality to include outputs and monitoring tables, ensuring full recovery of machine-related data.  

### Changes
- Added restore logic for machine outputs.  
- Added restore logic for cumulative outputs.  
- Added restore logic for monitoring table.  
- Wrapped operations in a transaction with try/catch for rollback on errors.  
- Maintained validation and permission checks.  

### Notes
- Ensure `$pdo` is properly initialized before use.  