### PR TITLE
fix(edit-machine): false positive on duplicate control number

### DIFF
--- a/app/controllers/edit_machine.php
+++ b/app/controllers/edit_machine.php
@@ -49,15 +49,15 @@ if ($description !== 'AUTOMATIC' && $description !== 'SEMI-AUTOMATIC') {
 // 3. Database operation
 // Check if the machine with the same control_no exists and is active
 $active_duplicate = getActiveMachineByControlNo($control_no);
-if ($active_duplicate && $active_duplicate['machine_id'] != $machine_id) {
-    jsAlertRedirect("An active machine with control_no: $control_no already exists.", $redirect_url);
+if ($active_duplicate && $active_duplicate['control_no'] != $control_no) {
+    jsAlertRedirect("An active machine with control number: $control_no already exists.", $redirect_url);
     exit;
 }
 
 // Check if the machine with the same control_no exists and is inactive
 $inactive_duplicate = getInactiveMachineByControlNo($control_no);
 if ($inactive_duplicate) {
-    jsAlertRedirect("A disabled machine with control_no: $control_no already exists.", $redirect_url);
+    jsAlertRedirect("A disabled machine with control number: $control_no already exists.", $redirect_url);
     exit;
 }
 

--- a/app/models/read_machines.php
+++ b/app/models/read_machines.php
@@ -176,7 +176,7 @@ function getActiveMachineByControlNo($control_no) {
         - $control_no: string, control number of the machine
 
         Returns:
-        - true if active machine exists
+        - associative array of row with same control_no if active machine exists
         - false if no active machine found
         - string containing error message on failure
     */
@@ -201,7 +201,7 @@ function getActiveMachineByControlNo($control_no) {
             return false;
         }
 
-        return true;
+        return $data;
 
     } catch (PDOException $e) {
         // Log error and return an error message on failure


### PR DESCRIPTION
### Summary
This PR resolves an issue in the edit-machine validation where updating a machine triggered a false positive duplicate check.  

### Changes
- Updated duplicate check logic to compare against `control_no` instead of `machine_id`
- Ensures that a machine can be updated with its existing control number without raising a duplicate error
- Returns proper message on success