### PR TITLE
fix(edit-applicator): false positive on duplicate hp_number

### DIFF
--- a/app/controllers/edit_applicator.php
+++ b/app/controllers/edit_applicator.php
@@ -57,14 +57,14 @@ if ($wire_type !== 'BIG' && $wire_type !== 'SMALL') {
 // Check if the applicator with the same hp_no exists and is active
 $active_duplicate = getActiveApplicatorByHpNo($hp_no);
 if ($active_duplicate && $active_duplicate['applicator_id'] != $applicator_id) {
-    jsAlertRedirect("An applicator with hp_no: $hp_no already exists.", $redirect_url);
+    jsAlertRedirect("An applicator with hp number: $hp_no already exists.", $redirect_url);
     exit;
 }
 
 // Check if the applicator with the same hp_no exists and is inactive
 $inactive_duplicate = getInactiveApplicatorByHpNo($hp_no);
 if ($inactive_duplicate) {
-    jsAlertRedirect("A disabled applicator with hp_no: $hp_no already exists.", $redirect_url);
+    jsAlertRedirect("A disabled applicator with hp number: $hp_no already exists.", $redirect_url);
     exit;
 }
 

--- a/app/models/read_applicators.php
+++ b/app/models/read_applicators.php
@@ -168,7 +168,7 @@ function getActiveApplicatorByHpNo($hp_no) {
         - $hp_no: HP number of the applicator.
 
         Returns:
-        - True if an active applicator exists.
+        - associative array of row with same hp_no if active machine exists
         - False if no active applicator exists.
         - String containing error message on failure.
     */
@@ -193,7 +193,7 @@ function getActiveApplicatorByHpNo($hp_no) {
             return false;
         }
 
-        return true;
+        return $data;
 
     } catch (PDOException $e) {
         // Log error and return an error message on failure


### PR DESCRIPTION
### Summary
This PR fixes an issue in the edit-applicator validation where updates triggered a false positive duplicate check.

### Changes
- Adjusted duplicate check to validate against `hp_number` instead of the current applicator’s ID
- Allows updating an applicator with its existing hp_number without raising a duplicate error
- Ensures proper error handling when a truly duplicate hp_number exists