### PR TITLE
refactor(auth): implement centralized role-based access control

### DIFF
--- a/app/controllers/add_applicator.php
+++ b/app/controllers/add_applicator.php
@@ -4,17 +4,15 @@
     It retrieves form data, sanitizes it, and inserts it into the database.
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../includes/db.php'; 
-include_once '../models/create_applicator.php';
+require_once '../models/create_applicator.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/add_entry.php";

--- a/app/controllers/add_custom_part.php
+++ b/app/controllers/add_custom_part.php
@@ -4,18 +4,16 @@
     It retrieves form data, sanitizes it, and inserts it into the database.
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../includes/db.php'; 
 require_once '../models/create_custom_part.php';
 require_once '../models/read_custom_parts.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/dashboard_applicator.php";

--- a/app/controllers/add_machine.php
+++ b/app/controllers/add_machine.php
@@ -4,20 +4,15 @@
     It retrieves form data, sanitizes it, and inserts it into the database.
 */
 
-ini_set("log_errors", 1);
-error_reporting(E_ALL);
-
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../includes/db.php'; 
-include_once '../models/create_machine.php';
+require_once '../models/create_machine.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/add_entry.php";

--- a/app/controllers/delete_custom_part.php
+++ b/app/controllers/delete_custom_part.php
@@ -4,17 +4,15 @@
     It retrieves the part ID, sanitizes it, and deletes the corresponding record.
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/dashboard_applicator.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../includes/db.php'; 
-include_once '../models/delete_custom_part.php';
+require_once '../models/delete_custom_part.php';
+
+// Require Admin Privileges
+requireAdmin();
 
 // Redirect url
 $redirect_url = "../views/dashboard_applicator.php";

--- a/app/controllers/disable_applicator.php
+++ b/app/controllers/disable_applicator.php
@@ -7,18 +7,16 @@
     - disable cumulative outputs of the applicator
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../models/delete_applicator.php';
 require_once '../models/update_applicator_output.php';
 require_once '../models/update_monitor_applicator.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/add_entry.php";

--- a/app/controllers/disable_machine.php
+++ b/app/controllers/disable_machine.php
@@ -7,18 +7,16 @@
     - disable cumulative outputs of the machine
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../models/delete_machines.php';
 require_once '../models/update_machine_output.php';
 require_once '../models/update_monitor_machine.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/add_entry.php";

--- a/app/controllers/disable_record.php
+++ b/app/controllers/disable_record.php
@@ -4,18 +4,16 @@
     It retrieves form data, sanitizes it, and updates the status in the database.
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../models/delete_record.php';
 require_once '../models/delete_applicator_output.php';
 require_once '../models/delete_machine_output.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/record_output.php";

--- a/app/controllers/edit_applicator.php
+++ b/app/controllers/edit_applicator.php
@@ -4,17 +4,15 @@
     It retrieves form data, sanitizes it, and updates the database record.
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
-include_once '../models/update_applicator.php';
-include_once '../models/read_applicators.php';
+require_once '../models/update_applicator.php';
+require_once '../models/read_applicators.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/add_entry.php";

--- a/app/controllers/edit_custom_part.php
+++ b/app/controllers/edit_custom_part.php
@@ -4,18 +4,16 @@
     It retrieves form data, sanitizes it, checks for duplicate part names, and updates the part record.
 */
 
-// Start session and check if user is logged in
-session_start();
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/db.php'; // Database connection
 require_once '../includes/js_alert.php'; // JavaScript alert function
 require_once '../models/read_custom_parts.php'; // Read custom part model
 require_once '../models/update_custom_part.php'; // Update custom part model
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect URL
 $redirect_url = "../views/dashboard_applicator.php";

--- a/app/controllers/edit_machine.php
+++ b/app/controllers/edit_machine.php
@@ -4,17 +4,15 @@
     It retrieves form data, sanitizes it, and updates the database record.
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
-include_once '../models/update_machine.php';
-include_once '../models/read_machines.php';
+require_once '../models/update_machine.php';
+require_once '../models/read_machines.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/add_entry.php";

--- a/app/controllers/edit_record.php
+++ b/app/controllers/edit_record.php
@@ -4,25 +4,23 @@
     It retrieves form data, sanitizes it, and updates the database record.
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/db.php';
 require_once '../includes/js_alert.php';
-include_once '../models/create_applicator_output.php';
-include_once '../models/read_machines.php';
-include_once '../models/read_applicators.php';
-include_once '../models/update_record.php';
-include_once '../models/update_applicator_output.php';
-include_once '../models/update_machine_output.php';
-include_once '../models/update_monitor_applicator.php';
-include_once '../models/update_monitor_machine.php';
-include_once '../models/delete_applicator_output.php';
+require_once '../models/create_applicator_output.php';
+require_once '../models/read_machines.php';
+require_once '../models/read_applicators.php';
+require_once '../models/update_record.php';
+require_once '../models/update_applicator_output.php';
+require_once '../models/update_machine_output.php';
+require_once '../models/update_monitor_applicator.php';
+require_once '../models/update_monitor_machine.php';
+require_once '../models/delete_applicator_output.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/record_output.php";

--- a/app/controllers/edit_user.php
+++ b/app/controllers/edit_user.php
@@ -4,18 +4,16 @@
     It retrieves form data, sanitizes it, checks for duplicate usernames, and updates the user record.
 */
 
-// Start session and check if user is logged in
-session_start();
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php'; // Authentication
 require_once '../includes/db.php'; // Database connection
 require_once '../includes/js_alert.php'; // JavaScript alert function
 require_once '../models/read_user.php'; // Read user model
 require_once '../models/update_user.php'; // Update user model
+
+// Require Admin Privileges
+requireAdmin();
 
 // Redirect URL
 $redirect_url = "../views/manage_user.php";

--- a/app/controllers/get_reset_dates_applicator.php
+++ b/app/controllers/get_reset_dates_applicator.php
@@ -4,7 +4,11 @@
 */
 
 
+require_once '../includes/auth.php';
 require_once '../models/read_applicator_reset.php';
+
+// Require Default Privileges
+requireDefault();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $part_name = $_POST['part_name'] ?? null;

--- a/app/controllers/get_reset_dates_machine.php
+++ b/app/controllers/get_reset_dates_machine.php
@@ -4,7 +4,11 @@
 */
 
 
+require_once '../includes/auth.php';
 require_once '../models/read_machine_reset.php';
+
+// Require Default Privileges
+requireDefault();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $part_name = $_POST['part_name'] ?? null;

--- a/app/controllers/record_output.php
+++ b/app/controllers/record_output.php
@@ -4,20 +4,18 @@
     It processes the form submission from the record output page and saves the data to the database.
 */
 
-// Ensure the user is logged in before proceeding
-session_start();
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit;
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../models/read_applicators.php';
 require_once '../models/read_machines.php';
 require_once '../models/create_record.php';
 require_once '../models/create_applicator_output.php';
 require_once '../models/create_machine_output.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // --- Redirect path ---
 $redirect = "../views/record_output.php";

--- a/app/controllers/reset_applicator.php
+++ b/app/controllers/reset_applicator.php
@@ -5,13 +5,16 @@
 */
 
 
-session_start();
-
+// Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../includes/db.php';
 require_once '../models/read_monitor_applicator.php';
 require_once '../models/create_applicator_reset.php';
 require_once '../models/update_monitor_applicator.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/dashboard_applicator.php";

--- a/app/controllers/reset_machine.php
+++ b/app/controllers/reset_machine.php
@@ -5,13 +5,16 @@
 */
 
 
-session_start();
-
+// Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../includes/db.php';
 require_once '../models/read_monitor_machine.php';
 require_once '../models/create_machine_reset.php';
 require_once '../models/update_monitor_machine.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/dashboard_machine.php";

--- a/app/controllers/restore_applicator.php
+++ b/app/controllers/restore_applicator.php
@@ -7,18 +7,16 @@
     - restore cumulative outputs of the applicator
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../models/update_applicator.php';
 require_once '../models/update_applicator_output.php';
 require_once '../models/update_monitor_applicator.php';
+
+// Require Admin Privileges
+requireAdmin();
 
 // Redirect url
 $redirect_url = "../views/dashboard_applicator.php";

--- a/app/controllers/restore_machine.php
+++ b/app/controllers/restore_machine.php
@@ -7,18 +7,16 @@
     - restore cumulative outputs of the machine
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../models/update_machine.php';
 require_once '../models/update_machine_output.php';
 require_once '../models/update_monitor_machine.php';
+
+// Require Admin Privileges
+requireAdmin();
 
 // Redirect url
 $redirect_url = "../views/dashboard_machine.php";

--- a/app/controllers/restore_record.php
+++ b/app/controllers/restore_record.php
@@ -4,18 +4,16 @@
     It retrieves form data, sanitizes it, and updates the database entry.
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../models/update_record.php';
 require_once '../models/update_applicator_output.php';
 require_once '../models/update_machine_output.php';
+
+// Require Admin Privileges
+requireAdmin();
 
 // Redirect url
 $redirect_url = "../views/record_output.php";

--- a/app/controllers/sign_up.php
+++ b/app/controllers/sign_up.php
@@ -87,6 +87,12 @@ if (is_array($result)) {
         $_SESSION['first_name'] = $result['first_name'];
         $_SESSION['user_type'] = $result['user_type'];
         header("Location: ../views/record_output.php");
+    } elseif ($user_type == 'ADMIN') {
+        $_SESSION['user_id'] = $result['user_id'];
+        $_SESSION['username'] = $result['username'];
+        $_SESSION['first_name'] = $result['first_name'];
+        $_SESSION['user_type'] = $result['user_type'];
+        header("Location: ../views/manage_user.php");
     } else {
         $_SESSION['user_id'] = $result['user_id'];
         $_SESSION['username'] = $result['username'];

--- a/app/controllers/undo_reset_applicator.php
+++ b/app/controllers/undo_reset_applicator.php
@@ -4,14 +4,9 @@
     It retrieves form data, sanitizes it, and updates the status in the database.
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../includes/db.php';
 require_once '../models/read_applicator_reset.php';
@@ -22,6 +17,8 @@ require_once '../models/read_records.php';
 require_once '../models/delete_applicator_output.php';
 require_once '../models/delete_machine_output.php';
 
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/dashboard_applicator.php";

--- a/app/controllers/undo_reset_machine.php
+++ b/app/controllers/undo_reset_machine.php
@@ -4,14 +4,9 @@
     It retrieves form data, sanitizes it, and updates the status in the database.
 */
 
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Include necessary files
+require_once '../includes/auth.php';
 require_once '../includes/js_alert.php';
 require_once '../includes/db.php';
 require_once '../models/read_machine_reset.php';
@@ -22,6 +17,8 @@ require_once '../models/read_records.php';
 require_once '../models/delete_applicator_output.php';
 require_once '../models/delete_machine_output.php';
 
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 // Redirect url
 $redirect_url = "../views/dashboard_machine.php";

--- a/app/controllers/upload.php
+++ b/app/controllers/upload.php
@@ -3,19 +3,18 @@
     This PHP code handles the file upload and ETL pipeline trigger for the file upload form in file_upload.php.
 */
 
+
+// Include necessary files
+require_once '../includes/auth.php';
 require_once __DIR__ . '/../includes/etl/extract.php';
 require_once __DIR__ . '/../includes/etl/transform.php';
 require_once __DIR__ . '/../includes/etl/load.php';
-require_once __DIR__ . '/../includes/db.php'; // Database connection
+require_once __DIR__ . '/../includes/db.php'; 
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
 
 $tempDir = __DIR__ . '/../temp/'; // Directory where uploaded files will be temporarily stored
-
-// Start session and check if user is logged in
-session_start(); 
-if (!isset($_SESSION['user_id'])) {
-    header("Location: ../views/login.php");
-    exit();
-}
 
 // Redirect url
 $redirect_url = "../views/file_upload.php";

--- a/app/includes/auth.php
+++ b/app/includes/auth.php
@@ -1,0 +1,45 @@
+<?php
+session_start();
+
+// Utility: check if a user is logged in
+function isAuthenticated(): bool {
+    return isset($_SESSION['user_type']);
+}
+
+// Utility: get current user role (defaults to 'DEFAULT')
+function getUserRole(): string {
+    return $_SESSION['user_type'] ?? "DEFAULT";
+}
+
+// Redirect helper
+function denyAccess($message = "You do not have the right permissions.") {
+    require_once __DIR__ . '/js_alert.php';
+    jsAlertRedirect($message, "../views/login.php");
+    exit;
+}
+
+/**
+ * Permission checks
+ * (Least privilege: higher roles inherit lower roles implicitly)
+ */
+
+// DEFAULT – can only view
+function requireDefault() {
+    if (!isAuthenticated()) {
+        denyAccess("Please log in to access this page.");
+    }
+}
+
+// TOOLKEEPER – default + edit/add machine/applicator/record, view disabled, upload
+function requireToolkeeper() {
+    if (!isAuthenticated() || !in_array(getUserRole(), ["TOOLKEEPER", "ADMIN"])) {
+        denyAccess("Toolkeeper or Admin privileges required.");
+    }
+}
+
+// ADMIN – toolkeeper + restore + manage users
+function requireAdmin() {
+    if (!isAuthenticated() || getUserRole() !== "ADMIN") {
+        denyAccess("Admin privileges required.");
+    }
+}


### PR DESCRIPTION
### Summary
This PR refactors authentication and authorization across the system to improve security and maintainability.

### Changes
- Created `auth.php` with centralized session handling and access control functions:
  - requireDefault() for authenticated users with basic view access
  - requireToolkeeper() for tool-related operations
  - requireAdmin() for system-level privileges
- Removed duplicate `session_start()` and login checks in individual controllers
- Updated controllers to use appropriate role checks (least privilege principle)
- Ensured models remain database-only without session logic
- Views can now conditionally hide/show features based on user role, while actual enforcement remains in controllers

### Notes
- Eliminates redundant code
- Consistent, role-based access enforcement
- Easier future maintenance when adding new roles or updating permissions