### PR TITLE
feat(disabled-applicators): implement search and filter functionality

### DIFF
--- a/app/controllers/search_disabled_applicators.php
+++ b/app/controllers/search_disabled_applicators.php
@@ -1,0 +1,46 @@
+<?php
+/*
+    Controller file for handling disabled-applicator search requests.
+    It retrieves query parameters from the frontend (search and role),
+    calls the model function to fetch the filtered disabled-applicators,
+    and returns the results in JSON format.
+*/
+
+require_once "../models/read_applicators.php";
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+    // Validate inputs
+    $search = isset($_GET['q']) ? trim($_GET['q']) : null;
+    if ($search === '') {
+        $search = null;
+    }
+
+    $description = isset($_GET['description']) ? strtoupper(trim($_GET['description'])) : 'ALL';
+    $allowedDescriptions = ['ALL', 'SIDE', 'END', 'CLAMP', 'STRIP AND CRIMP'];
+    if (!in_array($description, $allowedDescriptions, true)) {
+        $description = 'ALL';
+    }
+
+    $type = isset($_GET['type']) ? strtoupper(trim($_GET['type'])) : 'ALL';
+    $allowedtype = ['ALL', 'BIG', 'SMALL'];
+    if (!in_array($type, $allowedtype, true)) {
+        $type = 'ALL';
+    }
+
+    // Fetch filtered results
+    $applicators = getFilteredApplicators(20, 0, $search, $description, $type, 0);
+
+    echo json_encode([
+        'success' => true,
+        'data' => $applicators
+    ]);
+
+} catch (Exception $e) {
+    // Return error as JSON
+    echo json_encode([
+        'success' => false,
+        'error' => $e->getMessage()
+    ]);
+}

--- a/app/views/dashboard_applicator.php
+++ b/app/views/dashboard_applicator.php
@@ -325,7 +325,7 @@
                     </div>
                     
                 <!-- Table 2: Recently Deleted Applicators -->
-                    <div class="data-section">
+                    <div class="data-section" id="disabled-applicators-section">
                         <div class="section-header">
                             <div class="section-title">
                                 📤 Recently Deleted Applicators
@@ -334,8 +334,23 @@
                             <div class="expand-icon">▼</div>
                         </div>
                         <div class="section-content expanded">
+                            <!-- Filters -->
                             <div class="search-filter">
-                                <input type="text" class="search-input" placeholder="Search deleted applicators...">
+                                <div class="search-filter">
+                                    <input type="text" class="search-input" placeholder="Search here..." onkeyup="applyDisabledApplicatorFilters()">
+                                </div>
+                                <select id="applicatorDescription" class="filter-select" onchange="applyDisabledApplicatorFilters()">  
+                                    <option value="ALL">All Types</option>
+                                    <option value="SIDE">SIDE</option>
+                                    <option value="END">END</option>
+                                    <option value="CLAMP">CLAMP</option>
+                                    <option value="STRIP AND CRIMP">STRIP AND CRIMP</option>
+                                </select>
+                                <select id="applicatorWireType" class="filter-select" onchange="applyDisabledApplicatorFilters()">  
+                                    <option value="ALL">All Types</option>
+                                    <option value="SMALL">Small</option>
+                                    <option value="BIG">Big</option>
+                                </select>
                             </div>
                             <div class="table-container">
                                 <table class="data-table">
@@ -346,7 +361,7 @@
                                                 <th>Description</th>
                                                 <th>Terminal Maker</th>
                                                 <th>Applicator Maker</th>
-                                                <th>Last Encoded</th>
+                                                <th>Last Updated</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -927,5 +942,7 @@
     <script src="../../public/assets/js/utils/exit.js"></script>
     <script src="../../public/assets/js/utils/enter.js"></script>
     <script src="../../public/assets/js/utils/checkbox.js"></script>
+    <!-- Search Disabled Applicators -->
+    <script src="../../public/assets/js/search_disabled_applicators.js"></script>
 </body>
 </html>

--- a/app/views/dashboard_machine.php
+++ b/app/views/dashboard_machine.php
@@ -303,7 +303,7 @@
                                         <th>Control Number</th>
                                         <th>Model</th>
                                         <th>Maker</th>
-                                        <th>Last Encoded</th>
+                                        <th>Last Updated</th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/public/assets/js/search_disabled_applicators.js
+++ b/public/assets/js/search_disabled_applicators.js
@@ -1,0 +1,75 @@
+let disabledApplicatorSearchTimeout = null;
+
+/*
+    Apply search and filter parameters to the disabled applicators table.
+    Debounced to prevent excessive requests while typing or changing filters.
+*/
+async function applyDisabledApplicatorFilters() {
+    clearTimeout(disabledApplicatorSearchTimeout);
+
+    disabledApplicatorSearchTimeout = setTimeout(async () => {
+        const section = document.getElementById('disabled-applicators-section');
+        const searchInput = section.querySelector('.search-input');
+        const search = searchInput ? searchInput.value.trim() : '';
+
+        const descriptionSelect = document.getElementById('applicatorDescription');
+        const description = descriptionSelect ? descriptionSelect.value : 'ALL';
+
+        const typeSelect = document.getElementById('applicatorWireType');
+        const type = typeSelect ? typeSelect.value : 'ALL';
+
+        try {
+            const response = await fetch(
+                `../controllers/search_disabled_applicators.php?q=${encodeURIComponent(search)}&description=${encodeURIComponent(description)}&type=${encodeURIComponent(type)}`
+            );
+            const result = await response.json();
+
+            if (!result.success) {
+                console.error("Disabled applicator search failed:", result.error);
+                updateDisabledApplicatorsTable([]); // show empty table if failed
+                return;
+            }
+
+            updateDisabledApplicatorsTable(result.data);
+        } catch (err) {
+            console.error("Disabled applicator search failed:", err);
+        }
+    }, 300);
+}
+
+/*
+    Update the disabled applicators table rows dynamically.
+*/
+function updateDisabledApplicatorsTable(applicators) {
+    const section = document.getElementById('disabled-applicators-section');
+    const tbody = section.querySelector(".data-table tbody");
+    tbody.innerHTML = "";
+
+    if (!applicators.length) {
+        tbody.innerHTML = "<tr><td colspan='6' style='text-align:center;'>No applicators found</td></tr>";
+        return;
+    }
+
+    applicators.forEach(applicator => {
+        const row = `
+            <tr>
+                <td>
+                    <div class="actions">
+                        <button class="restore-btn" type="button"
+                            data-applicator-id="${applicator.applicator_id}"
+                            onclick="restoreApplicator(this)">
+                            Restore
+                        </button>
+                    </div>
+                </td>
+                <td>${applicator.hp_no}</td>
+                <td>${applicator.description}</td>
+                <td>${applicator.terminal_maker}</td>
+                <td>${applicator.applicator_maker}</td>
+                <td>${applicator.last_encoded || ''}</td>
+            </tr>
+        `;
+        tbody.insertAdjacentHTML("beforeend", row);
+    });
+}
+


### PR DESCRIPTION
### Summary
This PR adds full search and filter functionality to the "Recently Deleted Applicators" table, similar to the disabled machines table.

### Changes
- Added debounced search input for HP number, terminal number, serial number, and invoice number.
- Added filters for Applicator Description and Wire Type.
- Updated JS to target the correct table and dynamically update rows.
- Adjusted PHP backend to handle search and filters securely with proper parameter binding.

### Notes
- Pagination is set to 20 rows by default.
- If no results are found, a "No applicators found" row is displayed.
- Functionality mirrors the disabled machines section for consistency.
