### PR TITLE
fix: Resolve overflow and improve layout for recently deleted applicators and custom parts

### DIFF
--- a/app/views/applicator_custom_parts.php
+++ b/app/views/applicator_custom_parts.php
@@ -1,8 +1,9 @@
 <div class="data-section">
-    <div class="section-header">
+    <div class="section-header expanded" onclick="toggleSection(this)">
         <div class="section-title">
-            🔧 Custom Parts
-            <span class="section-badge">3</span>
+            <span class="filter-info">
+                🔧 Custom Parts
+            </span>
         </div>
         <div class="expand-icon">▼</div>
     </div>
@@ -11,7 +12,7 @@
             <input type="text" class="search-input" placeholder="Search custom parts...">
         </div>
         <div class="table-container">
-            <table class="data-table">
+            <table class="data-table" id="customPartsTable">
                 <thead>
                     <tr>
                         <th>Part Name</th>
@@ -24,25 +25,29 @@
                     <!-- Wire Crimper -->
                     <tr>
                         <td><?= htmlspecialchars(ucwords(str_replace('_', ' ', $part['part_name']))) ?></td>
-                        <td><?= htmlspecialchars(date('Y-m-d', strtotime($part['created_at']))) ?></td>
+                        <td><strong><?= htmlspecialchars(date('Y-m-d', strtotime($part['created_at']))) ?></strong></td>
                         <td>
                             <div class="actions">
                                 <?php $partNameTitle = ucwords(str_replace('_', ' ', strtolower($part['part_name']))); ?>
-                                <button class="edit-btn" 
-                                        data-part-id="<?= htmlspecialchars($part['part_id']) ?>" 
-                                        data-part-name="<?= htmlspecialchars($partNameTitle, ENT_QUOTES) ?>">
+                                <button
+                                    class="edit-btn"
+                                    type="button"
+                                    data-part-id="<?= htmlspecialchars($part['part_id']) ?>"
+                                    data-part-name="<?= htmlspecialchars($partNameTitle, ENT_QUOTES) ?>">
                                     Edit
                                 </button>
-                                <button class="delete-btn" 
-                                        data-part-id="<?= htmlspecialchars($part['part_id']) ?>" 
-                                        data-part-type="MACHINE">
+                                <button
+                                    class="delete-btn"
+                                    type="button"
+                                    data-part-id="<?= htmlspecialchars($part['part_id']) ?>"
+                                    data-part-type="APPLICATOR">
                                     Delete
                                 </button>
                             </div>
                         </td>
                     </tr>
                     <?php endforeach; ?>
-                </tbody>  
+                </tbody>
             </table>
         </div>
     </div>

--- a/app/views/dashboard_applicator.php
+++ b/app/views/dashboard_applicator.php
@@ -280,11 +280,13 @@
                     <?php include_once __DIR__ . '/applicator_custom_parts.php'; ?>
                     
                 <!-- Table 2: Recently Deleted Applicators -->
-                    <?php include_once __DIR__ . '/recently_deleted_applicator.php'; ?>
+                    <div class="tables-scroll-2">
+                        <?php include_once __DIR__ . '/recently_deleted_applicator.php'; ?>
+                    </div>
                 </div>
 
                     <!-- Table 3: Recently Deleted Record -->
-                <div class="full-width-table" style="position: relative; top: -65px;">
+                <div class="full-width-table" style="position: relative; top: -50px;">
                     <?php include_once __DIR__ . '/recently_deleted_outputs_table.php'; ?>
                 </div>
             </div>

--- a/app/views/recently_deleted_applicator.php
+++ b/app/views/recently_deleted_applicator.php
@@ -1,62 +1,59 @@
 <div class="data-section" id="disabled-applicators-section">
-    <div class="section-header">
+    <div class="section-header expanded" onclick="toggleSection(this)">
         <div class="section-title">
-            📤 Recently Deleted Applicators
-            <span class="section-badge">3</span>
+            <span class="filter-info">
+                📤 Recently Deleted Applicators
+            </span>
         </div>
         <div class="expand-icon">▼</div>
     </div>
+    <div class="search-filter">
+        <input type="text" class="search-input" placeholder="Search here..." onkeyup="applyDisabledApplicatorFilters()">
+        <select id="applicatorDescription" class="filter-select" onchange="applyDisabledApplicatorFilters()">  
+            <option value="ALL">All Types</option>
+            <option value="SIDE">SIDE</option>
+            <option value="END">END</option>
+            <option value="CLAMP">CLAMP</option>
+            <option value="STRIP AND CRIMP">STRIP AND CRIMP</option>
+        </select>
+        <select id="applicatorWireType" class="filter-select" onchange="applyDisabledApplicatorFilters()">  
+            <option value="ALL">All Types</option>
+            <option value="SMALL">Small</option>
+            <option value="BIG">Big</option>
+        </select>
+    </div>
     <div class="section-content expanded">
-        <!-- Filters -->
-        <div class="search-filter">
-            <div class="search-filter">
-                <input type="text" class="search-input" placeholder="Search here..." onkeyup="applyDisabledApplicatorFilters()">
-            </div>
-            <select id="applicatorDescription" class="filter-select" onchange="applyDisabledApplicatorFilters()">  
-                <option value="ALL">All Types</option>
-                <option value="SIDE">SIDE</option>
-                <option value="END">END</option>
-                <option value="CLAMP">CLAMP</option>
-                <option value="STRIP AND CRIMP">STRIP AND CRIMP</option>
-            </select>
-            <select id="applicatorWireType" class="filter-select" onchange="applyDisabledApplicatorFilters()">  
-                <option value="ALL">All Types</option>
-                <option value="SMALL">Small</option>
-                <option value="BIG">Big</option>
-            </select>
-        </div>
         <div class="table-container">
-            <table class="data-table">
-                    <thead>
-                        <tr>
-                            <th>Actions</th>
-                            <th>HP Number</th>
-                            <th>Description</th>
-                            <th>Terminal Maker</th>
-                            <th>Applicator Maker</th>
-                            <th>Last Updated</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($disabled_applicators as $applicator): ?>
-                        <tr>
-                            <td>
-                                <button id="restore-applicator-<?= htmlspecialchars($applicator['applicator_id']) ?>"
-                                        class="restore-btn restore-applicator-btn"
-                                        data-applicator-id="<?= htmlspecialchars($applicator['applicator_id']) ?>">
-                                    Restore
-                                </button>
-                            </td>
-                            <td><?php echo htmlspecialchars($applicator['hp_no']); ?></td>
-                            <td><?php echo htmlspecialchars($applicator['description']); ?></td>
-                            <td><?php echo htmlspecialchars($applicator['terminal_maker']); ?></td>
-                            <td><?php echo htmlspecialchars($applicator['applicator_maker']); ?></td>
-                            <td><?php echo htmlspecialchars($applicator['last_encoded']); ?></td>
-                        </tr>
-                        <?php endforeach; ?>
-                    </tbody>
-                </table>
-            </div>
+            <table class="data-table" id="metricsTable">
+                <thead>
+                    <tr>
+                        <th>Actions</th>
+                        <th>HP Number</th>
+                        <th>Description</th>
+                        <th>Terminal Maker</th>
+                        <th>Applicator Maker</th>
+                        <th>Last Updated</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($disabled_applicators as $applicator): ?>
+                    <tr>
+                        <td>
+                            <button id="restore-applicator-<?= htmlspecialchars($applicator['applicator_id']) ?>"
+                                    class="restore-btn restore-applicator-btn"
+                                    data-applicator-id="<?= htmlspecialchars($applicator['applicator_id']) ?>">
+                                Restore
+                            </button>
+                        </td>
+                        <td><?php echo htmlspecialchars($applicator['hp_no']); ?></td>
+                        <td><?php echo htmlspecialchars($applicator['description']); ?></td>
+                        <td><?php echo htmlspecialchars($applicator['terminal_maker']); ?></td>
+                        <td><?php echo htmlspecialchars($applicator['applicator_maker']); ?></td>
+                        <td><?php echo htmlspecialchars($applicator['last_encoded']); ?></td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
         </div>
     </div>
-<div>
+</div>

--- a/public/assets/css/layout/grid.css
+++ b/public/assets/css/layout/grid.css
@@ -6,6 +6,11 @@
     margin-bottom: 40px;
 }
 
+.tables-scroll-2 {
+    overflow-x: auto;
+    overflow-y: auto;
+}
+
 .full-width-table {
     grid-column: 1 / -1;
 }


### PR DESCRIPTION
- Remove inline overflow styles from recently deleted applicator section
- Add tables-scroll-2 wrapper for better scroll handling
- Move recently deleted applicators back to side-by-side grid layout
- Remove section badge from recently deleted applicators header
- Restore original positioning for recently deleted outputs table
- Improve visual organization and eliminate unwanted scrollbars