### PR TITLE
feat(ajax): move initial records fetch to AJAX

### DIFF
--- a/app/controllers/search_records.php
+++ b/app/controllers/search_records.php
@@ -11,34 +11,41 @@ require_once "../models/read_joins/record_and_outputs.php";
 header('Content-Type: application/json; charset=utf-8');
 
 try {
-    // Validate inputs
+    // Search
     $search = isset($_GET['q']) ? strtoupper(trim($_GET['q'])) : null;
     if ($search === '') {
         $search = null;
     }
 
+    // Shift filter
     $shift = isset($_GET['shift']) ? trim($_GET['shift']) : 'ALL';
     $allowedShifts = ['ALL', '1st', '2nd', 'NIGHT'];
     if (!in_array($shift, $allowedShifts, true)) {
         $shift = 'ALL';
     }
 
-    $type = isset($_GET['type']) ? trim($_GET['type']) : 'ALL';
-    $allowedtype = ['ALL', 'BIG', 'SMALL']; 
-    if (!in_array($type, $allowedtype, true)) {
-        $type = 'ALL';
-    }
+    // Pagination
+    $page  = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
+    $limit = isset($_GET['limit']) ? max(1, (int)$_GET['limit']) : 20;
+    $offset = ($page - 1) * $limit;
 
     // Fetch filtered results
-    $records = getFilteredrecords(20, 0, $search, $shift);
+    $records = getFilteredRecords($limit, $offset, $search, $shift);
+
+    // Simplest efficient check:
+    // If nothing is returned AND page=1 AND no filters applied
+    $emptyDb = false;
+    if (empty($records) && $page === 1 && $search === null && $shift === 'ALL') {
+        $emptyDb = true;
+    }
 
     echo json_encode([
         'success' => true,
-        'data' => $records
+        'data' => $records,
+        'empty_db' => $emptyDb
     ]);
 
 } catch (Exception $e) {
-    // Return error as JSON
     echo json_encode([
         'success' => false,
         'error' => $e->getMessage()

--- a/app/views/record_output.php
+++ b/app/views/record_output.php
@@ -112,55 +112,8 @@ if (!isset($_SESSION['user_id'])) {
                                     <th>Machine</th>
                                     <th>Machine Output</th>
                             </thead>
-
-                            <?php   
-                            // Include database connection and machine reader logic
-                            require_once __DIR__ . '/../includes/db.php';
-                            require_once __DIR__ . '/../models/read_joins/record_and_outputs.php';
-
-                            // Fetch initial set of machines (first 20 entries)
-                            $records = getRecordsAndOutputs(20, 0);
-                            ?>
-
                             <tbody id="recordsTableBody">
-                                <!-- Render fetched machine data as table rows -->
-                                <?php foreach ($records as $row): ?>
-                                    <tr>
-                                        <td>
-                                            <div class="actions">
-                                                <button class="edit-btn" onclick="openRecordEditModalSafe(this); return false;" 
-                                                    data-id="<?= htmlspecialchars($row['record_id']) ?>"
-                                                    data-date-inspected="<?= htmlspecialchars($row['date_inspected']) ?>"
-                                                    data-shift="<?= htmlspecialchars($row['shift']) ?>"
-                                                    data-hp1-no="<?= htmlspecialchars($row['hp1_no'] ?? '') ?>"
-                                                    data-app1-output="<?= htmlspecialchars($row['app1_output'] ?? '') ?>"
-                                                    data-hp2-no="<?= htmlspecialchars($row['hp2_no'] ?? '') ?>"
-                                                    data-app2-output="<?= htmlspecialchars($row['app2_output'] ?? '') ?>"
-                                                    data-control-no="<?= htmlspecialchars($row['control_no'] ?? '') ?>"
-                                                    data-machine-output="<?= htmlspecialchars($row['machine_output'] ?? '') ?>"
-                                                    title="Edit Record" 
-                                                >Edit</button>
-
-                                                <!-- Delete form -->
-                                                <form action="/SOMS/app/controllers/disable_record.php" method="POST" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this record?');">
-                                                    <input type="hidden" name="record_id" value="<?= htmlspecialchars($row['record_id']) ?>">
-                                                    <button type="submit" title="Delete Record" class="delete-btn">Delete</button>
-                                                </form>
-                                            </div>
-                                        </td>
-                                        <td><?= htmlspecialchars($row['record_id']) ?></td>
-                                        <td><?= htmlspecialchars($row['date_inspected']) ?></td>
-                                        <td><?= htmlspecialchars(explode(' ', $row['date_encoded'])[0]) ?></td>
-                                        <td><?= htmlspecialchars(explode(' ', $row['last_updated'])[0]) ?></td>
-                                        <td><?= htmlspecialchars($row['shift']) ?></td>
-                                        <td><?= htmlspecialchars($row['hp1_no']) ?></td>
-                                        <td><?= htmlspecialchars($row['app1_output']) ?></td>
-                                        <td><?= htmlspecialchars($row['hp2_no']) ?></td>
-                                        <td><?= htmlspecialchars($row['app2_output']) ?></td>
-                                        <td><?= htmlspecialchars($row['control_no']) ?></td>
-                                        <td><?= htmlspecialchars($row['machine_output']) ?></td>
-                                    </tr>
-                                <?php endforeach; ?>
+                                <!-- Render fetched machine data as table rows through AJAX -->
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
### Summary
This PR updates the **Records Output table** to fetch initial data dynamically using AJAX instead of relying on pre-rendered HTML.  
It ensures the table properly displays:

- Records on initial page load
- "No records available yet" when the database is empty
- Works seamlessly with search and shift filters

### Key Changes
- Added `applyRecordFilters()` call on DOMContentLoaded to fetch initial records.
- Updated `updateRecordsTable()` to handle empty DB (`empty_db`) vs no search results.
- Removed reliance on static preloaded table rows for the initial load.

### Benefits
- Reduces duplication between initial load and filter/search logic.
- Makes the table ready for future pagination or infinite scroll.
- Keeps frontend and backend logic consistent.
