### PR TITLE
feat(machines): AJAX initial fetch with loading spinner and emptyDb handling

### DIFF
--- a/app/controllers/search_machines.php
+++ b/app/controllers/search_machines.php
@@ -11,24 +11,27 @@ require_once "../models/read_machines.php";
 header('Content-Type: application/json; charset=utf-8');
 
 try {
-    // Validate inputs
     $search = isset($_GET['q']) ? trim($_GET['q']) : null;
-    if ($search === '') {
-        $search = null;
-    }
+    $page  = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
+    $limit = isset($_GET['limit']) ? max(1, (int)$_GET['limit']) : 20;
+    $offset = ($page - 1) * $limit;
+
+    if ($search === '') $search = null;
 
     $description = isset($_GET['description']) ? strtoupper(trim($_GET['description'])) : 'ALL';
     $allowedDescriptions = ['ALL', 'AUTOMATIC', 'SEMI-AUTOMATIC'];
-    if (!in_array($description, $allowedDescriptions, true)) {
-        $description = 'ALL';
-    }
+    if (!in_array($description, $allowedDescriptions, true)) $description = 'ALL';
 
     // Fetch filtered results
-    $machines = getFilteredMachines(20, 0, $search, $description);
+    $machines = getFilteredMachines($limit, $offset, $search, $description);
+
+    // Determine if DB is empty (initial fetch)
+    $emptyDb = empty($machines) && $page === 1 && $search === null && $description === 'ALL';
 
     echo json_encode([
         'success' => true,
-        'data' => $machines
+        'data' => $machines,
+        'empty_db' => $emptyDb
     ]);
 
 } catch (Exception $e) {

--- a/app/views/add_entry.php
+++ b/app/views/add_entry.php
@@ -114,47 +114,7 @@ if (!isset($_SESSION['user_id'])) {
                                     </tr>
                                 </thead>
                                 <tbody id="machine-body">
-                                    <?php
-                                    // Include database connection and machine reader logic
-                                    require_once __DIR__ . '/../includes/db.php';
-                                    require_once __DIR__ . '/../models/read_machines.php';
-
-                                    // Fetch initial set of machines (first 10 entries)
-                                    $machines = getMachines($pdo, 20, 0);?>
-
-                                    <!-- Render fetched machine data as table rows -->
-                                    <?php foreach ($machines as $row): ?>
-                                        <tr>
-                                            <td>
-                                            <!-- Edit link with data attributes -->
-                                                <div class="actions">
-                                                    <button class="edit-btn"
-                                                        type="button"
-                                                        onclick="openEditModal(this)"
-                                                        data-id="<?= $row['machine_id'] ?>"
-                                                        data-control="<?= htmlspecialchars($row['control_no'], ENT_QUOTES) ?>"
-                                                        data-description="<?= $row['description'] ?>"
-                                                        data-model="<?= htmlspecialchars($row['model'], ENT_QUOTES) ?>"
-                                                        data-maker="<?= htmlspecialchars($row['maker'], ENT_QUOTES) ?>"
-                                                        data-serial="<?= htmlspecialchars($row['serial_no'], ENT_QUOTES) ?>"
-                                                        data-invoice="<?= htmlspecialchars($row['invoice_no'], ENT_QUOTES) ?>"
-                                                    >Edit</button>
-
-                                            <!-- Delete form -->
-                                                    <form action="/SOMS/app/controllers/disable_machine.php" method="POST" style="display:inline;">
-                                                        <input type="hidden" name="machine_id" value="<?= $row['machine_id'] ?>">
-                                                        <button class="delete-btn" type="button" onclick="openMachineDeleteModal(this)">Delete</button>
-                                                    </form>
-                                                </div>
-                                            </td>
-                                            <td><?= htmlspecialchars($row['control_no']) ?></td>
-                                            <td><?= htmlspecialchars($row['description']) ?></td>
-                                            <td><?= htmlspecialchars($row['model']) ?></td>
-                                            <td><?= htmlspecialchars($row['maker']) ?></td>
-                                            <td><?= htmlspecialchars($row['serial_no']) ?></td>
-                                            <td><?= htmlspecialchars($row['invoice_no']) ?></td>
-                                        </tr>
-                                    <?php endforeach; ?>
+                                    <!-- Fetch machine data as table rows via AJAX-->
                                 </tbody>
                             </table>
                         </div>

--- a/public/assets/js/search_machines.js
+++ b/public/assets/js/search_machines.js
@@ -1,47 +1,73 @@
+// Timer for debouncing search input to reduce number of fetch requests
 let machineSearchTimeout = null;
 
 /*
     Apply search and description filters to the machine table.
     Debounced to prevent too many requests.
 */
-async function applyMachineFilters() {
+async function applyMachineFilters(searchValue = '', page = 1, limit = 20) {
+    // Clear any pending timeout to debounce
     clearTimeout(machineSearchTimeout);
 
+    // Set a new debounce timeout
     machineSearchTimeout = setTimeout(async () => {
-        const search = document.querySelector('.search-input').value.trim();
+        // Get search query from input field if not passed directly
+        const search = searchValue.trim() || document.getElementById('machineSearchInput').value.trim();
+
+        // Get selected machine description filter
         const description = document.getElementById('machineDescription').value;
 
+        const tbody = document.getElementById("machine-body");
+
+        // Show loading spinner while fetching data
+        tbody.innerHTML = `
+            <tr>
+                <td colspan="12" style="text-align:center;">
+                    <div class="loading-spinner"></div>
+                </td>
+            </tr>
+        `;
+
         try {
+            // Fetch filtered machine data from the controller
             const response = await fetch(
-                `../controllers/search_machines.php?q=${encodeURIComponent(search)}&description=${encodeURIComponent(description)}`
+                `../controllers/search_machines.php?q=${encodeURIComponent(search)}&description=${encodeURIComponent(description)}&page=${page}&limit=${limit}`
             );
             const result = await response.json();
 
+            // If fetch failed or controller returned error
             if (!result.success) {
                 console.error("Machine search failed:", result.error);
-                updateMachineTable([]); // show empty table if failed
+                updateMachineTable([], false); // Render empty table
                 return;
             }
 
-            updateMachineTable(result.data);
+            // Update table with fetched data and emptyDb info
+            updateMachineTable(result.data, result.empty_db);
         } catch (err) {
+            // Log network or unexpected errors
             console.error("Machine search failed:", err);
+            updateMachineTable([], false);
         }
-    }, 300);
+    }, 300); // Wait 300ms before triggering fetch
 }
 
 /*
     Update the table rows dynamically.
 */
-function updateMachineTable(machines) {
+function updateMachineTable(machines, emptyDb) {
     const tbody = document.getElementById("machine-body");
-    tbody.innerHTML = "";
+    tbody.innerHTML = ""; // Clear existing rows
 
+    // Handle empty table
     if (!machines.length) {
-        tbody.innerHTML = "<tr><td colspan='7'>No machines found</td></tr>";
+        tbody.innerHTML = emptyDb
+            ? `<tr><td colspan="12" style="text-align:center;">No machines available yet</td></tr>`
+            : `<tr><td colspan="12" style="text-align:center;">No results found</td></tr>`;
         return;
     }
 
+    // Loop through each machine and create table rows
     machines.forEach(machine => {
         const row = `
             <tr>
@@ -71,6 +97,11 @@ function updateMachineTable(machines) {
                 <td>${machine.invoice_no}</td>
             </tr>
         `;
-        tbody.insertAdjacentHTML("beforeend", row);
+        tbody.insertAdjacentHTML("beforeend", row); // Append new row
     });
 }
+
+// Load initial machine data on page load
+document.addEventListener("DOMContentLoaded", () => {
+    applyMachineFilters(); // Initial fetch without filters
+});


### PR DESCRIPTION
### Summary
This PR converts the Machines Table to load its initial data via AJAX.  
It provides a dynamic experience with a loading spinner during slow fetches and properly handles empty database scenarios.

### Key Changes
- Added `applyMachineFilters()` to fetch machines asynchronously with debounce.
- Updated `updateMachineTable()` to display:
  - "No machines available yet" when database is empty.
  - "No results found" when no machines match the search/filters.
- Added loading spinner while fetching data.
- Initial data is now loaded on page load using AJAX.

### Notes
- Backend controller updated to return `empty_db` flag to distinguish empty database vs no search results.
- Frontend now fully decoupled from PHP-rendered initial rows, enabling smoother pagination/filtering in the future.