### PR TITLE
feat(export): enable applicator reset export with validation and safeguards

### DIFF
--- a/app/controllers/export_applicator_reset.php
+++ b/app/controllers/export_applicator_reset.php
@@ -1,0 +1,79 @@
+<?php
+/*
+    This script handles the export logic for applicator reset records within the database.
+    It retrieves form data, sanitizes it, and updates the database record.
+*/
+
+
+// Include necessary files
+require_once '../includes/auth.php';
+require_once '../includes/js_alert.php';
+require_once '../includes/export_helpers/export_applicator_reset_helper.php';
+require_once '../models/read_applicator_reset.php';
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
+
+// Redirect url
+$redirect_url = "../views/dashboard_applicator.php";
+
+// Check if the request method is POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    jsAlertRedirect("Invalid request method.", $redirect_url);
+    exit;
+}
+
+// 1. Sanitize input
+$date_range      = isset($_POST['dateRange']) ? htmlspecialchars(trim($_POST['dateRange'])) : 'today';
+$include_headers = isset($_POST['includeHeaders']) ? 1 : 0;
+$start_date      = isset($_POST['startDate']) ? htmlspecialchars(trim($_POST['startDate'])) : null;
+$end_date        = isset($_POST['endDate']) ? htmlspecialchars(trim($_POST['endDate'])) : null;
+
+// 2. Validation
+// Validate required fields
+if (empty($date_range)) {
+    jsAlertRedirect("Please select a date range.", $redirect_url);
+    exit;
+}
+if ($date_range === 'custom' && (empty($start_date) || empty($end_date))) {
+    jsAlertRedirect("Please provide both start and end dates for custom range.", $redirect_url);
+    exit;
+}
+
+// Validate date range
+$valid_ranges = ['today', 'week', 'month', 'quarter', 'custom'];
+if (!in_array($date_range, $valid_ranges)) {
+    jsAlertRedirect("Invalid date range option.", $redirect_url);
+    exit;
+}
+
+// If custom date range, validate both start and end
+if ($date_range === 'custom') {
+    if (empty($start_date) || empty($end_date)) {
+        jsAlertRedirect("Both start and end dates are required for custom range.", $redirect_url);
+        exit;
+    } elseif (strtotime($start_date) > strtotime($end_date)) {
+        jsAlertRedirect("Start date cannot be later than end date.", $redirect_url);
+        exit;
+    } else {
+        // Validate interval does not exceed 12 months
+        $start = new DateTime($start_date);
+        $end   = new DateTime($end_date);
+
+        $diff = $start->diff($end);
+        $totalMonths = ($diff->y * 12) + $diff->m;
+
+        if ($diff->d > 0) {
+            $totalMonths += 1;
+        }
+
+        if ($totalMonths > 3) {
+            jsAlertRedirect("Custom date range cannot exceed 3 months.", $redirect_url);
+            exit;
+        }
+    }
+}
+
+// Pass data into export helper
+exportApplicatorResetsToExcel($include_headers, $date_range, $start_date, $end_date);
+exit;

--- a/app/includes/export_helpers/export_applicator_reset_helper.php
+++ b/app/includes/export_helpers/export_applicator_reset_helper.php
@@ -1,0 +1,98 @@
+<?php
+/*
+    This is a helper file for exporting applicator resets to Excel.
+*/
+
+// Include error handling and set max memory limits and execution time
+require_once '../includes/error_handler.php';
+ini_set('memory_limit', '512M');
+set_time_limit(300);
+
+require_once '../../vendor/autoload.php';
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+require_once '../models/read_applicator_reset.php';
+
+/*
+    Export applicator resets to Excel, splitting into multiple sheets if > 5000 rows.
+
+    Params: 
+    bool $include_headers - Whether to include column headers
+    string $date_range    - The selected date filter (today, week, month, quarter, year, or custom)
+    string $start_date    - Start date if custom range
+    string $end_date      - End date if custom range
+*/
+function exportApplicatorResetsToExcel($include_headers, $date_range, $start_date = null, $end_date = null) {
+
+    $records = getApplicatorResetForExport($date_range, $start_date, $end_date);
+
+    if (!$records) {
+        jsAlertRedirect("No applicator reset records found for export.", '../views/applicator_reset.php');
+    }
+
+    $spreadsheet = new Spreadsheet();
+
+    // Split into chunks of 5000
+    $chunks = array_chunk($records, 5000);
+
+    foreach ($chunks as $i => $chunk) {
+        if ($i === 0) {
+            $sheet = $spreadsheet->getActiveSheet();
+        } else {
+            $sheet = $spreadsheet->createSheet($i);
+        }
+
+        $sheet->setTitle("Resets_" . ($i + 1));
+
+        $rowNum = 1;
+
+        // Headers
+        if ($include_headers && isset($chunk[0])) {
+            $col = 1;
+            foreach (array_keys($chunk[0]) as $header) {
+                $cell = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($col) . $rowNum;
+                $sheet->setCellValue($cell, ucfirst(str_replace("_", " ", $header)));
+                $sheet->getStyle($cell)->getFont()->setBold(true);
+                $col++;
+            }
+            $rowNum++;
+        }
+
+        // Data rows
+        foreach ($chunk as $record) {
+            $col = 1;
+            foreach ($record as $value) {
+                $cell = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($col) . $rowNum;
+                $sheet->setCellValue($cell, $value);
+                $col++;
+            }
+            $rowNum++;
+        }
+
+        // Auto-size columns
+        foreach (range(1, count($chunk[0])) as $colIndex) {
+            $colLetter = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($colIndex);
+            $sheet->getColumnDimension($colLetter)->setAutoSize(true);
+        }
+    }
+
+    $spreadsheet->setActiveSheetIndex(0);
+
+    // Clear any previous output
+    if (ob_get_length()) {
+        ob_end_clean();
+    }
+
+    header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    header('Content-Disposition: attachment;filename="applicator_resets_export.xlsx"');
+    header('Cache-Control: max-age=0');
+    header('Cache-Control: max-age=1'); // For IE compatibility
+    header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+    header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+    header('Cache-Control: cache, must-revalidate');
+    header('Pragma: public');
+
+    $writer = new Xlsx($spreadsheet);
+    $writer->save('php://output');
+    exit;
+}

--- a/app/models/read_applicator_reset.php
+++ b/app/models/read_applicator_reset.php
@@ -82,3 +82,57 @@ function getApplicatorResetOnTimeStamp($applicator_id, $part_name, $reset_time) 
         return "Database error occurred: " . htmlspecialchars($e->getMessage(), ENT_QUOTES);
     }
 }
+
+function getApplicatorResetForExport($date_range = 'quarter', $start_date = null, $end_date = null) {
+    /*
+        Model function to fetch applicator reset records.
+        This function will be used for exporting applicator reset records to Excel.
+
+        Parameters:
+            str $date_range - The date range for the export (e.g., 'today', 'week', 'month', 'quarter', 'custom').
+            str $start_date - The start date for the custom date range (optional).
+            str $end_date - The end date for the custom date range (optional).
+    */
+    global $pdo;
+
+    $query = "
+        SELECT a.hp_no,
+            a.terminal_no,
+            u.first_name,
+            u.last_name,
+            ar.reset_time,
+            ar.part_reset,
+            ar.previous_value
+        FROM applicator_reset ar
+        LEFT JOIN applicators a
+            ON ar.applicator_id = a.applicator_id
+        LEFT JOIN users u
+            ON ar.reset_by = u.user_id
+        WHERE ar.undone_by IS NULL
+    ";
+
+    // Apply date range filters
+    if ($date_range === 'custom' && $start_date && $end_date) {
+        $query .= " AND reset_time BETWEEN :start_date AND :end_date";
+    } else {
+        $date_filter = match ($date_range) {
+            'today' => "DATE(reset_time) = CURDATE()",
+            'week' => "YEARWEEK(reset_time, 1) = YEARWEEK(CURDATE(), 1)",
+            'month' => "MONTH(reset_time) = MONTH(CURDATE()) AND YEAR(reset_time) = YEAR(CURDATE())",
+            'quarter' => "QUARTER(reset_time) = QUARTER(CURDATE()) AND YEAR(reset_time) = YEAR(CURDATE())",
+            default => "1=1"
+        };
+        $query .= " AND $date_filter";
+    }
+
+    $stmt = $pdo->prepare($query);
+
+    // Bind parameters for custom date range
+    if ($date_range === 'custom' && $start_date && $end_date) {
+        $stmt->bindParam(':start_date', $start_date);
+        $stmt->bindParam(':end_date', $end_date);
+    }
+
+    $stmt->execute();
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}

--- a/app/views/applicator_recently_reset.php
+++ b/app/views/applicator_recently_reset.php
@@ -11,7 +11,7 @@
             <p class="form-subtitle">Generate reports for recently reset applicators</p>
         </div>
 
-        <form id="exportForm" method="POST" action="../controllers/export_reset_applicator.php">
+        <form id="exportForm" method="POST" action="../controllers/export_applicator_reset.php">
             <div class="form-section">
                 <div class="info-section">
                     <div style="display: flex; align-items: flex-start; gap: 8px;">
@@ -56,16 +56,11 @@
                         <span class="checkbox-label">Include column headers</span>
                     </label>
                 </div>
-
-
             </div>
-
-
-            
 
             <div class="button-group">
                 <button type="button" class="cancel-btn" onclick="closeExportModal()">Cancel</button>
-                <button type="submit" class="export-btn" onclick="handleExport(this)">
+                <button type="submit" class="export-btn">
                     📊 Generate Export
                 </button>
             </div>

--- a/app/views/machine_recently_reset.php
+++ b/app/views/machine_recently_reset.php
@@ -58,9 +58,6 @@
                 </div>
             </div>
 
-
-            
-
             <div class="button-group">
                 <button type="button" class="cancel-btn" onclick="closeExportModal()">Cancel</button>
                 <button type="submit" class="export-btn" onclick="handleExport(this)">


### PR DESCRIPTION
### Summary
This PR introduces the ability to **export applicator reset records** into Excel format.  
The implementation includes safeguards for performance, validation, and centralized error handling.

### Key Changes
- Added helper for exporting applicator reset data with PhpSpreadsheet.
- Implemented support for standard date ranges (`today`, `week`, `month`, `quarter`) and custom ranges.
- Enforced **maximum 3-month limit** on custom date intervals to prevent heavy queries.
- Chunked large datasets into sheets of **5000 rows each** for stability.
- Integrated **global shutdown error handler** to catch fatal errors and redirect users gracefully.
- Applied memory (`512M`) and execution time (`300s`) limits during export.

### Notes
- Max expected size per export: ~150,000 rows.
- Custom range beyond 3 months will be rejected with a JS alert and redirect.