### PR TITLE
feat(upload): enforce max 3 files and 15MB total for uploads

### DIFF
--- a/app/controllers/upload.php
+++ b/app/controllers/upload.php
@@ -25,52 +25,72 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     exit();
 }
 
+// Check if the temp dir is empty
+if (!isset($_FILES['dataFiles'])) { 
+    jsAlertRedirect("No files uploaded.", $redirect_url);
+    exit();
+}
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['dataFiles'])) { // If the dataFiles field exists in the $_FILES array (means user uploaded one or more files).
-    try {
-        foreach ($_FILES['dataFiles']['tmp_name'] as $index => $tmpName) { // Loops through all uploaded files.
-            $fileName = basename($_FILES['dataFiles']['name'][$index]); // Extracts the original filename of the uploaded file.
-            $targetPath = $tempDir . $fileName; // Constructs the full path (where to move the file) inside app/temp/ directory.
-            
-            // File size limit check
-            $maxFileSize = 5 * 1024 * 1024; // 5 MB
-            if ($_FILES['dataFiles']['size'][$index] > $maxFileSize) {
-                jsAlertRedirect("Error: File '$fileName' exceeds the 5MB size limit.", $redirect_url);
-                exit();
-            }
+try {
+    $fileCount = count($_FILES['dataFiles']['name']);
+    $totalSize = array_sum($_FILES['dataFiles']['size']);
 
-            // Moves the uploaded file to the target path.
-            if (move_uploaded_file($tmpName, $targetPath)) { 
-                $pdo->beginTransaction();
-                    // Extract
-                    $rawData = extractData($targetPath); 
-                    if (is_string($rawData)) {
-                        jsAlertRedirect($rawData, $redirect_url);
-                        exit();
-                    }
-
-                    // Transform and Load
-                    $cleanData = transformData($rawData); 
-                    $result = loadData($cleanData); 
-                    if ($result === "All outputs recorded successfully!") {
-                        $pdo->commit();
-                        unlink($targetPath); // Deletes the file after ETL
-                        jsAlertRedirect($result, $redirect_url); // Redirects to the etl_form.php with success message
-                    } else {
-                        $pdo->rollBack(); // Rollback transaction in case of error
-                        unlink($targetPath); // Deletes the file if there was an error
-                        jsAlertRedirect($result, $redirect_url); // Redirects to the etl_form.php with error message
-                        exit();
-                    }
-            }
-        }
-
-    } catch (Exception $e) {
-        $pdo->rollBack(); // Rollback transaction in case of exception
-        if (isset($targetPath) && file_exists($targetPath)) {
-            unlink($targetPath); // Delete uploaded file if it exists
-        }
-        jsAlertRedirect("Error processing files: " . $e->getMessage() . " Trashing the uploaded file.", $redirect_url); // Redirect with error message
+    // Max file count check
+    $maxFiles = 3;
+    if ($fileCount > $maxFiles) {
+        jsAlertRedirect("Error: You can only upload up to $maxFiles files at once.", $redirect_url);
         exit();
     }
+
+    // Max total size check (15 MB)
+    $maxTotalSize = 15 * 1024 * 1024; // 15 MB
+    if ($totalSize > $maxTotalSize) {
+        jsAlertRedirect("Error: Total upload size exceeds 15MB.", $redirect_url);
+        exit();
+    }
+
+    foreach ($_FILES['dataFiles']['tmp_name'] as $index => $tmpName) { // Loops through all uploaded files.
+        $fileName = basename($_FILES['dataFiles']['name'][$index]); // Extracts the original filename of the uploaded file.
+        $targetPath = $tempDir . $fileName; // Constructs the full path (where to move the file) inside app/temp/ directory.
+        
+        //  Per-file size check 
+        $maxFileSize = 5 * 1024 * 1024; // 5 MB
+        if ($_FILES['dataFiles']['size'][$index] > $maxFileSize) {
+            jsAlertRedirect("Error: File '$fileName' exceeds the 5MB size limit.", $redirect_url);
+            exit();
+        }
+
+        // Moves the uploaded file to the target path.
+        if (move_uploaded_file($tmpName, $targetPath)) { 
+            $pdo->beginTransaction();
+                // Extract
+                $rawData = extractData($targetPath); 
+                if (is_string($rawData)) {
+                    jsAlertRedirect($rawData, $redirect_url);
+                    exit();
+                }
+
+                // Transform and Load
+                $cleanData = transformData($rawData); 
+                $result = loadData($cleanData); 
+                if ($result === "All outputs recorded successfully!") {
+                    $pdo->commit();
+                    unlink($targetPath); // Deletes the file after ETL
+                    jsAlertRedirect($result, $redirect_url); // Redirects to the etl_form.php with success message
+                } else {
+                    $pdo->rollBack(); // Rollback transaction in case of error
+                    unlink($targetPath); // Deletes the file if there was an error
+                    jsAlertRedirect($result, $redirect_url); // Redirects to the etl_form.php with error message
+                    exit();
+                }
+        }
+    }
+
+} catch (Exception $e) {
+    $pdo->rollBack(); // Rollback transaction in case of exception
+    if (isset($targetPath) && file_exists($targetPath)) {
+        unlink($targetPath); // Delete uploaded file if it exists
+    }
+    jsAlertRedirect("Error processing files: " . $e->getMessage() . " Trashing the uploaded file.", $redirect_url); // Redirect with error message
+    exit();
 }


### PR DESCRIPTION
### Summary
This update adds additional constraints to the ETL upload process:
- Maximum 3 files per upload
- Maximum 5MB size  per file
- Maximum total size of 15MB per batch

### Key Changes
- Added server-side checks for file count and total size before processing.
- Displays clear error messages if limits are exceeded.
- Ensures ETL pipeline is only triggered for valid uploads.

### Notes
- Limits are configurable via `$maxFiles` and `$maxTotalSize` variables.
- Prevents overloading the system with large or too many files.
