### PR TITLE
fix(upload): prevent filename collisions by adding unique prefix

### DIFF
--- a/app/controllers/upload.php
+++ b/app/controllers/upload.php
@@ -51,7 +51,7 @@ try {
 
     foreach ($_FILES['dataFiles']['tmp_name'] as $index => $tmpName) { // Loops through all uploaded files.
         $fileName = basename($_FILES['dataFiles']['name'][$index]); // Extracts the original filename of the uploaded file.
-        $targetPath = $tempDir . $fileName; // Constructs the full path (where to move the file) inside app/temp/ directory.
+        $targetPath = $tempDir . uniqid() . "_" . $fileName; // Constructs the full path (where to move the file) inside app/temp/ directory.
         
         //  Per-file size check 
         $maxFileSize = 5 * 1024 * 1024; // 5 MB


### PR DESCRIPTION
### Summary  
This update improves the file upload process by ensuring that uploaded files are saved with a unique identifier to prevent collisions.  
Previously, two users uploading files with the same name (e.g., `data.csv`) at the same time could overwrite each other’s files in the temporary directory.

### Key Changes  
- Added a unique prefix (`uniqid()`) to every uploaded filename before saving to the `app/temp/` directory.  
- Ensured ETL extraction, cleanup, and feedback still use the original filename for user-facing messages.  
- Prevented overwrites and data loss during concurrent uploads.
