### PR TITLE
feat(export): add Excel export for machine data with headers option

### DIFF
--- a/app/controllers/export_machine.php
+++ b/app/controllers/export_machine.php
@@ -1,0 +1,38 @@
+<?php
+/*
+    This script serves as the controller that handles the export logic for machine data to excel.
+    It retrieves form data, sanitizes it, and updates the database record.
+*/
+
+
+// Include necessary files
+require_once '../includes/auth.php';
+require_once '../includes/js_alert.php';
+require_once '../includes/export_helpers/export_machine_helper.php';
+require_once '../models/read_machines.php';
+
+
+// Require Toolkeeper/Admin Privileges
+requireToolkeeper();
+
+// Redirect url
+$redirect_url = "../views/add_entry.php";
+
+// Check if the request method is POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    jsAlertRedirect("Invalid request method.", $redirect_url);
+    exit;
+}
+
+// 1. Sanitize input
+$include_headers = isset($_POST['includeHeaders']) ? 1 : 0;
+
+// 2. Validation
+if (empty($include_headers)) {
+    jsAlertRedirect("Please specify whether to include headers.", $redirect_url);
+    exit;
+}
+
+// Pass data into export helper
+exportMachineToExcel($include_headers);
+exit;

--- a/app/includes/export_helpers/export_machine_helper.php
+++ b/app/includes/export_helpers/export_machine_helper.php
@@ -1,0 +1,95 @@
+<?php
+/*
+    This is a helper file for exporting machine output to Excel.
+*/
+
+// Include error handling and set max memory limits and execution time
+require_once '../includes/error_handler.php';
+ini_set('memory_limit', '512M');
+set_time_limit(300);
+
+require_once '../../vendor/autoload.php';
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+
+/*
+    Export records to Excel, splitting into multiple sheets if > 5000 rows.
+
+    Params: 
+    bool $include_headers - Whether to include column headers
+    string $filters - SQL filter string for fetching records
+*/
+function exportMachineToExcel($include_headers) {
+
+    $records = getMachinesForExport();
+
+    if (!$records) {
+        jsAlertRedirect("No records found for export.", '../views/dashboard_machine.php');
+    }
+
+    $spreadsheet = new Spreadsheet();
+
+    // Split into chunks of 5000
+    $chunks = array_chunk($records, 5000);
+
+    foreach ($chunks as $i => $chunk) {
+        if ($i === 0) {
+            $sheet = $spreadsheet->getActiveSheet();
+        } else {
+            $sheet = $spreadsheet->createSheet($i);
+        }
+
+        $sheet->setTitle("MachineResets_" . ($i + 1));
+
+        $rowNum = 1;
+
+        // Headers
+        if ($include_headers && isset($chunk[0])) {
+            $col = 1;
+            foreach (array_keys($chunk[0]) as $header) {
+                $cell = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($col) . $rowNum;
+                $sheet->setCellValue($cell, ucfirst(str_replace("_", " ", $header)));
+                $sheet->getStyle($cell)->getFont()->setBold(true);
+                $col++;
+            }
+            $rowNum++;
+        }
+
+        // Data rows
+        foreach ($chunk as $record) {
+            $col = 1;
+            foreach ($record as $value) {
+                $cell = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($col) . $rowNum;
+                $sheet->setCellValue($cell, $value);
+                $col++;
+            }
+            $rowNum++;
+        }
+
+        // Auto-size columns
+        foreach (range(1, count($chunk[0])) as $colIndex) {
+            $colLetter = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($colIndex);
+            $sheet->getColumnDimension($colLetter)->setAutoSize(true);
+        }
+    }
+
+    $spreadsheet->setActiveSheetIndex(0);
+
+    // Clear any previous output
+    if (ob_get_length()) {
+        ob_end_clean();
+    }
+
+    header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    header('Content-Disposition: attachment;filename="machine_data_export.xlsx"');
+    header('Cache-Control: max-age=0');
+    header('Cache-Control: max-age=1'); // For IE compatibility
+    header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+    header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+    header('Cache-Control: cache, must-revalidate');
+    header('Pragma: public');
+
+    $writer = new Xlsx($spreadsheet);
+    $writer->save('php://output');
+    exit;
+}

--- a/app/models/read_machines.php
+++ b/app/models/read_machines.php
@@ -270,3 +270,38 @@ function getFilteredMachines(int $limit = 20, int $offset = 0, ?string $search =
     $stmt->execute();
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
+
+
+function getMachinesForExport() {
+    /*
+        Function to fetch all active machines for export.
+
+        Returns:
+        - Array of machines (associative arrays) on success.
+        - Empty array if no records found.
+    */
+
+    global $pdo;
+
+    // Prepare the SQL statement
+    $stmt = $pdo->prepare("
+        SELECT 
+            control_no, 
+            description,
+            model,
+            maker, 
+            serial_no, 
+            invoice_no,
+            last_encoded
+        FROM 
+            machines
+        WHERE 
+            is_active = 1
+        ORDER BY
+            machine_id DESC
+    ");
+
+    // Execute the query and return the results
+    $stmt->execute();
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}

--- a/app/views/add_entry.php
+++ b/app/views/add_entry.php
@@ -632,10 +632,10 @@ if (!isset($_SESSION['user_id'])) {
                     <div class="form-container">
                         <button class="modal-close-btn" onclick="closeExportMachineModal()">×</button>
                         
-                        <form method="POST" action="../controllers/export_machine_output.php">
+                        <form method="POST" action="../controllers/export_machine.php">
                             <div class="form-header">
-                                <h1 class="form-title">Export Machine Output Data</h1>
-                                <p style="font-size: 14px; color: #6B7280;">Generate reports for machine outputs</p>
+                                <h1 class="form-title">Export Machine Data</h1>
+                                <p style="font-size: 14px; color: #6B7280;">Generate reports for machine data</p>
                             </div>
 
                             <!-- Export Format Section -->
@@ -645,7 +645,7 @@ if (!isset($_SESSION['user_id'])) {
                                         <span class="info-icon">ℹ️</span>
                                         <div>
                                             <strong>Export Information</strong>
-                                            <p>The report will include all current machine outputs. The data will be exported in Excel format.</p>
+                                            <p>The report will include all current machine data. The data will be exported in Excel format.</p>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
### Summary
This PR introduces functionality to export **Machine data** into Excel format.  
Users can now generate Excel reports with an option to include column headers.

### Key Changes
- Added export modal for **Machine data**.
- Implemented controller to handle export requests securely.
- Created helper function to generate Excel files with:
  - Column headers (optional).
  - Auto-sized columns.
  - Data chunking for large datasets (>5000 rows).
- Integrated error handling for missing/invalid inputs.
- Added memory and execution limit safeguards for large exports.

### Notes
- Export file is delivered in `.xlsx` format named `machine_data_export.xlsx`.  
- Only active and valid machine records are included.  
- Error alerts redirect users back to the machine dashboard when no records are found.
