### PR TITLE
refactor(applicator-dashboard): replace hardcoded limits with DB-driven per-applicator limits

### DIFF
--- a/app/controllers/get_dashboard_outputs.php
+++ b/app/controllers/get_dashboard_outputs.php
@@ -1,184 +1,156 @@
 <?php
+/*
+    Controller: Handles progress bar computation for the Applicator Dashboard.
+    
+    Responsibilities:
+    - Accepts JSON payload from ProgressBarManager (DOM -> JS -> PHP).
+    - Maps each applicator/part output to its configured part limits.
+    - Computes percentage usage and assigns a status (green/yellow/red).
+    - Returns JSON response with computed progress per applicator.
+*/
+
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+// Output JSON
 header('Content-Type: application/json');
-require_once '../includes/db.php';
+
+// Include dependencies
+require_once '../models/read_applicator_limits.php';
 
 try {
-    // Get applicator ID from request
-    $applicator_id = $_GET['applicator_id'] ?? null;
-    
-    // Include the same model that the dashboard uses
-    require_once '../models/read_custom_parts.php';
-    require_once '../models/read_applicator_limits.php';
-    require_once '../models/read_joins/read_monitor_applicator_and_applicator.php';
-    
-    // Get custom parts (same as dashboard)
-    $custom_applicator_parts = getCustomParts("APPLICATOR");
-    $part_names_array = [];
+    /*
+        Step 1: Decode the request payload
+        - ProgressBarManager sends POST JSON with applicator_id + parts (current, limit from DOM).
+        - Example:
+          {
+            "applicators": [
+              {
+                "applicator_id": "A1",
+                "parts": {
+                  "wire_crimper": { "current": 123456, "limit": 400000 }
+                }
+              }
+            ]
+          }
+    */
+    $input = json_decode(file_get_contents('php://input'), true);
 
-    // Get all part limits of applicators
-    $part_limits = getPartLimitsOfApplicators("APPLICATOR");
+    if (!$input || !isset($input['applicators'])) {
+        echo json_encode(['success' => false, 'message' => 'Invalid payload']);
+        exit;
+    }
+
+    /*
+        Step 2: Load applicator part limits from DB
+        - applicator_part_limits table contains per-applicator overrides.
+        - Build a map like:
+          [
+            "A1|wire_crimper" => 400000,
+            "A2|shear_blade"  => 500000
+          ]
+    */
+    $part_limits = getApplicatorPartLimits();
     $limits = [];
     foreach ($part_limits as $row) {
-        // join key1 and key2 into one string key
         $composite_key = $row['applicator_id'] . '|' . $row['applicator_part'];
         $limits[$composite_key] = $row['part_limit'];
     }
 
-    foreach ($custom_applicator_parts as $part) {
-        $part_names_array[] = $part['part_name'];
+    /*
+        Step 3: Process each applicator from the payload
+        - For each part, decide the correct limit:
+          1. Use applicator-specific override if exists.
+          2. Else use default per part name (fallback).
+          3. Else fallback to 500k.
+        - Compute percentage + color status.
+    */
+    $responseData = [];
+
+    foreach ($input['applicators'] as $applicator) {
+        $applicatorId = $applicator['applicator_id'] ?? null;
+        $parts = $applicator['parts'] ?? [];
+
+        if (!$applicatorId) continue;
+
+        $progress = [];
+
+        foreach ($parts as $partName => $partData) {
+        $current = (int)($partData['current'] ?? 0);
+
+        // Strip "custom_parts_" if present
+        $normalizedPart = preg_replace('/^custom_parts_/', '', $partName);
+
+        // Lookup applicator-specific override, else fallback
+        $composite_key = $applicatorId . '|' . $normalizedPart;
+        $limit = $limits[$composite_key] 
+            ?? getDefaultLimitForPart($normalizedPart) 
+            ?? 500000;
+
+        // Compute % usage and assign a status
+        $percentage = getPercent($current, $limit);
+        $status = getPercentColor($current, $limit);
+
+        // Keep original $partName so JS can still map to the DOM <td>
+        $progress[$partName] = [
+            'current'    => $current,
+            'limit'      => $limit,
+            'percentage' => $percentage,
+            'status'     => $status,
+        ];
     }
-    
-    if ($applicator_id) {
-        // Get specific applicator using same logic as dashboard
-        $search_result = searchApplicatorByHpNo($applicator_id, $part_names_array);
-        
-        if (!empty($search_result)) {
-            $outputs = calculateDashboardProgressPercentages($search_result[0]);
-            echo json_encode(['success' => true, 'data' => $outputs]);
-        } else {
-            echo json_encode(['success' => false, 'message' => 'Applicator not found']);
-        }
-    } else {
-        // Get all applicators using same logic as dashboard
-        $applicator_total_outputs = getApplicatorRecordsAndOutputs(10, 0, $part_names_array);
-        
-        $outputs = [];
-        foreach ($applicator_total_outputs as $row) {
-            $outputs[] = calculateDashboardProgressPercentages($row);
-        }
-        
-        echo json_encode(['success' => true, 'data' => $outputs]);
+
+        $responseData[] = [
+            'applicator_id' => $applicatorId,
+            'progress'      => $progress,
+        ];
     }
-    
+
+    /*
+        Step 4: Return final response
+        - Shape matches what ProgressBarManager expects.
+    */
+    echo json_encode(['success' => true, 'data' => $responseData]);
+
 } catch (Exception $e) {
-    echo json_encode(['success' => false, 'message' => 'Database error: ' . $e->getMessage()]);
+    // Log and return error JSON
+    error_log('Dashboard outputs error: ' . $e->getMessage());
+    echo json_encode(['success' => false, 'message' => 'Server error']);
 }
 
-function calculateDashboardProgressPercentages($data) {
-    // 400k group - handle reset values (0 means reset)
-    $wire_crimper_progress = $data['wire_crimper_output'] <= 0 ? 0 : min(100, round(($data['wire_crimper_output'] / 400000.0) * 100, 2));
-    if ($wire_crimper_progress < 0.01) $wire_crimper_progress = 0;
-    
-    $wire_anvil_progress = $data['wire_anvil_output'] <= 0 ? 0 : min(100, round(($data['wire_anvil_output'] / 400000.0) * 100, 2));
-    if ($wire_anvil_progress < 0.01) $wire_anvil_progress = 0;
-    
-    $insulation_crimper_progress = $data['insulation_crimper_output'] <= 0 ? 0 : min(100, round(($data['insulation_crimper_output'] / 400000.0) * 100, 2));
-    if ($insulation_crimper_progress < 0.01) $insulation_crimper_progress = 0;
-    
-    $insulation_anvil_progress = $data['insulation_anvil_output'] <= 0 ? 0 : min(100, round(($data['insulation_anvil_output'] / 400000.0) * 100, 2));
-    if ($insulation_anvil_progress < 0.01) $insulation_anvil_progress = 0;
-    
-    $slide_cutter_progress = $data['slide_cutter_output'] <= 0 ? 0 : min(100, round(($data['slide_cutter_output'] / 400000.0) * 100, 2));
-    if ($slide_cutter_progress < 0.01) $slide_cutter_progress = 0;
-    
-    // 500k group
-    $cutter_holder_progress = $data['cutter_holder_output'] <= 0 ? 0 : min(100, round(($data['cutter_holder_output'] / 500000.0) * 100, 2));
-    if ($cutter_holder_progress < 0.01) $cutter_holder_progress = 0;
-    
-    $shear_blade_progress = $data['shear_blade_output'] <= 0 ? 0 : min(100, round(($data['shear_blade_output'] / 500000.0) * 100, 2));
-    if ($shear_blade_progress < 0.01) $shear_blade_progress = 0;
-    
-    // 600k group
-    $cutter_a_progress = $data['cutter_a_output'] <= 0 ? 0 : min(100, round(($data['cutter_a_output'] / 600000.0) * 100, 2));
-    if ($cutter_a_progress < 0.01) $cutter_a_progress = 0;
-    
-    $cutter_b_progress = $data['cutter_b_output'] <= 0 ? 0 : min(100, round(($data['cutter_b_output'] / 600000.0) * 100, 2));
-    if ($cutter_b_progress < 0.01) $cutter_b_progress = 0;
-    
-    // Build the progress array
-    $progress = [
-        'wire_crimper' => [
-            'current' => $data['wire_crimper_output'],
-            'limit' => 400000,
-            'percentage' => $wire_crimper_progress,
-            'status' => getStatusColor($wire_crimper_progress)
-        ],
-        'wire_anvil' => [
-            'current' => $data['wire_anvil_output'],
-            'limit' => 400000,
-            'percentage' => $wire_anvil_progress,
-            'status' => getStatusColor($wire_anvil_progress)
-        ],
-        'insulation_crimper' => [
-            'current' => $data['insulation_crimper_output'],
-            'limit' => 400000,
-            'percentage' => $insulation_crimper_progress,
-            'status' => getStatusColor($insulation_crimper_progress)
-        ],
-        'insulation_anvil' => [
-            'current' => $data['insulation_anvil_output'],
-            'limit' => 400000,
-            'percentage' => $insulation_anvil_progress,
-            'status' => getStatusColor($insulation_anvil_progress)
-        ],
-        'slide_cutter' => [
-            'current' => $data['slide_cutter_output'],
-            'limit' => 400000,
-            'percentage' => $slide_cutter_progress,
-            'status' => getStatusColor($slide_cutter_progress)
-        ],
-        'cutter_holder' => [
-            'current' => $data['cutter_holder_output'],
-            'limit' => 500000,
-            'percentage' => $cutter_holder_progress,
-            'status' => getStatusColor($cutter_holder_progress)
-        ],
-        'shear_blade' => [
-            'current' => $data['shear_blade_output'],
-            'limit' => 500000,
-            'percentage' => $shear_blade_progress,
-            'status' => getStatusColor($shear_blade_progress)
-        ],
-        'cutter_a' => [
-            'current' => $data['cutter_a_output'],
-            'limit' => 600000,
-            'percentage' => $cutter_a_progress,
-            'status' => getStatusColor($cutter_a_progress)
-        ],
-        'cutter_b' => [
-            'current' => $data['cutter_b_output'],
-            'limit' => 600000,
-            'percentage' => $cutter_b_progress,
-            'status' => getStatusColor($cutter_b_progress)
-        ]
-    ];
-    
-    // Add custom parts to progress data
-    if (!empty($data['custom_parts_output']) && is_array($data['custom_parts_output'])) {
-        foreach ($data['custom_parts_output'] as $partName => $total) {
-            // Ensure total is a valid number and default to 0 if not
-            $total = is_numeric($total) ? (int)$total : 0;
-            
-            // For custom parts, ensure 0 shows as exactly 0% (no tiny progress bar)
-            // Use strict comparison and handle very small values
-            if ($total <= 0) {
-                $custom_progress = 0;
-            } else {
-                $custom_progress = min(100, round(($total / 600000.0) * 100, 2));
-                // Additional check: if the calculated percentage is very small (less than 0.01%), set it to 0
-                if ($custom_progress < 0.01) {
-                    $custom_progress = 0;
-                }
-            }
-            
-            $progress["custom_parts_$partName"] = [
-                'current' => $total,
-                'limit' => 600000,
-                'percentage' => $custom_progress,
-                'status' => getStatusColor($custom_progress)
-            ];
-        }
-    }
-    
-    return [
-        'applicator_id' => $data['applicator_id'],
-        'hp_no' => $data['hp_no'] ?? '',
-        'progress' => $progress
-    ];
+
+
+/* -------------------------- HELPERS -------------------------- */
+
+function getPercent($output, $limit) {
+    /*
+        Compute percentage = output / limit * 100
+    */
+    if ($output <= 0 || $limit <= 0) return 0;
+    return round(($output / $limit) * 100);
 }
 
-function getStatusColor($percentage) {
-    if ($percentage < 70) return 'green';    // OK
-    if ($percentage < 90) return 'yellow';   // Warning
-    return 'red';                            // Replace
+
+function getPercentColor($output, $limit) {
+    /*
+        Map percentage to status color
+        - green   = safe (< 70%)
+        - yellow  = warning (70%–89%)
+        - red     = critical (>= 90%)
+    */
+    $percent = getPercent($output, $limit);
+    if ($percent < 70) return 'green';
+    if ($percent < 90) return 'yellow';
+    return 'red';
+}
+
+
+function getDefaultLimitForPart($part) {
+    /*
+        Fallback limits per part type if no DB override is found
+    */
+    if (in_array($part, ['wire_crimper','wire_anvil','insulation_crimper','insulation_anvil','slide_cutter'])) return 500000;
+    if (in_array($part, ['cutter_holder','shear_blade'])) return 500000;
+    return 500000; // cutter_a, cutter_b, and custom parts
 }

--- a/app/models/read_applicator_limits.php
+++ b/app/models/read_applicator_limits.php
@@ -7,10 +7,18 @@
 */
 
 // Include the database connection
-require_once __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../includes/db.php';
 
 function getApplicatorPartLimits() {
-    $pdo = getDbConnection();
+    /*
+        Fetch all applicator part limits from the database.
+        Returns an associative array of applicator part limits.
+
+        Used in the applicator dashboard to determine part limits for each applicator.
+    */
+
+    global $pdo;
+
     $stmt = $pdo->prepare("SELECT 
         applicator_id,
         applicator_part,


### PR DESCRIPTION
## Summary
This PR refactors the Applicator Dashboard progress computation to remove hardcoded part limits and redundant data fetching. The JS now gathers values directly from the already-rendered table (DOM), posts them to a PHP controller, which computes percentages and statuses using per-applicator limits loaded from the database. The result is a cleaner, more flexible, and lower-query approach.

## Key Changes
- PHP controller
  - Added `getApplicatorPartLimits()` to fetch all limits from `models/applicator_part_limits`.
  - Built a fast lookup map keyed by `"applicator_id|applicator_part"` (concat of applicator id and part name including custom parts).
  - Normalized custom parts by stripping the `custom_parts_` prefix when mapping.
  - For each applicator/part from the payload:
    - Use applicator-specific limit when present; otherwise fall back to per-part defaults.
    - Compute percentage (current/limit) and map to status: green (<70%), yellow (70–89%), red (>=90%).
  - Return a JSON payload shaped for the `ProgressBarManager` (per applicator, per part).

- JavaScript (`ProgressBarManager`)
  - Waits ~50ms after `DOMContentLoaded`.
  - Parses each row in `#metricsBody`, reads current output and limit text from the table cells, and builds a DOM-sourced payload.
  - Posts the payload to the PHP controller to compute percentages and statuses.
  - Applies the returned progress:
    - Sets progress bar width, status class, and tooltip.
    - Updates the display text with formatted current and the resolved limit.
  - Exposes `window.refreshProgressFromDOM()` to re-run the pipeline when needed.

## Benefits
- Fewer DB queries
  - JS no longer fetches data that is already rendered. It reuses the DOM as the source of truth for current output values.
- Flexible and data-driven
  - Limits come from `applicator_part_limits`, enabling per-applicator overrides without code changes.
  - Default per-part limits still work when no override exists.
- Cleaner, less fragile logic
  - Eliminates scattered hardcoded thresholds in both PHP and JS.
  - Consolidates percentage/status computation on the server for consistency.
- Easier maintenance
  - Changing a limit in the DB immediately affects the dashboard—no redeploy required.
  - New custom parts automatically flow through as long as the DOM cell uses `data-part` and the table displays the number.

## Testing/validation
- Load the dashboard; progress bars should render correctly after ~50ms.
- Verify tooltips show “current / limit (x%)”.
- Update a limit in `applicator_part_limits` and refresh; the bar should reflect the new limit immediately.
- Confirm custom parts (`data-part="custom_parts_<name>"`) compute and display correctly.
- 0 values show 0% (no tiny slivers).
- Status classes map correctly: <70 green, 70–89 yellow, >=90 red.
- Network tab: POST to the controller returns `application/json` (no HTML/warnings).

## Implementation notes
- Controller reads JSON payload from `php://input` and returns JSON; ensure no stray output before headers.
- Ensure the controller endpoint is accessible from the browser (no 404). 

## Risk/rollback
- Low risk. Changes are localized to the PHP controller and the dashboard JS.
- Rollback plan: revert to the previous controller and JS that used hardcoded limits and/or separate data fetch.

## Checklist
- [ / ] Controller returns valid JSON with correct headers
- [ / ] No duplicate or conflicting script includes
- [ / ] Paths to controller verified for the current codespace
- [ / ] Spot-checked multiple applicators and custom parts
- [ / ] Insert new common part limit for an appicator in db table then check if the ui changed
- [ / ] Insert new custom part limit for an appicator in db table then check if the ui changed