### PR TITLE
fix(js-alert): enforce script termination after alert redirects

### DIFF
--- a/app/controllers/record_output.php
+++ b/app/controllers/record_output.php
@@ -154,3 +154,4 @@ if (is_string($machine_monitor_status)) {
 // If all operations were successful, redirect to the record output page with success message
 $pdo->commit();
 jsAlertRedirect("All outputs recorded successfully!", $redirect);
+exit;

--- a/app/controllers/sign_up.php
+++ b/app/controllers/sign_up.php
@@ -81,6 +81,7 @@ if (is_array($result)) {
     $pdo->commit();
     if (isset($_POST['admin_create_user'])) {
         jsAlertRedirect("User created successfully.", $redirect_url);
+        exit;
     } elseif ($user_type == 'TOOLKEEPER') {
         $_SESSION['user_id'] = $result['user_id'];
         $_SESSION['username'] = $result['username'];

--- a/app/controllers/update_password.php
+++ b/app/controllers/update_password.php
@@ -75,4 +75,3 @@ if ($result === true) {
     jsAlertRedirect($result, $redirect_url);
     exit;
 }
-?>

--- a/app/includes/error_handler.php
+++ b/app/includes/error_handler.php
@@ -12,6 +12,7 @@ register_shutdown_function(function () {
         // You can customize this message for exports only if needed
         if (php_sapi_name() !== 'cli') {
             jsAlertRedirect("Export failed due to system limits. Please try again with a smaller date range.", '../views/home.php');
+            exit;
         }
     }
 });

--- a/app/includes/export_helpers/export_applicator_helper.php
+++ b/app/includes/export_helpers/export_applicator_helper.php
@@ -25,6 +25,7 @@ function exportApplicatorToExcel($include_headers) {
 
     if (!$records) {
         jsAlertRedirect("No records found for export.", '../views/dashboard_applicator.php');
+        exit;
     }
 
     $spreadsheet = new Spreadsheet();

--- a/app/includes/export_helpers/export_applicator_output_helper.php
+++ b/app/includes/export_helpers/export_applicator_output_helper.php
@@ -25,6 +25,7 @@ function exportApplicatorOutputToExcel($include_headers) {
 
     if (!$records) {
         jsAlertRedirect("No records found for export.", '../views/dashboard_applicator.php');
+        exit;
     }
 
     // Extract only the part_name values from custom applicator parts 

--- a/app/includes/export_helpers/export_applicator_reset_helper.php
+++ b/app/includes/export_helpers/export_applicator_reset_helper.php
@@ -28,6 +28,7 @@ function exportApplicatorResetsToExcel($include_headers, $date_range, $start_dat
 
     if (!$records) {
         jsAlertRedirect("No applicator reset records found for export.", '../views/applicator_reset.php');
+        exit;
     }
 
     $spreadsheet = new Spreadsheet();

--- a/app/includes/export_helpers/export_machine_helper.php
+++ b/app/includes/export_helpers/export_machine_helper.php
@@ -25,6 +25,7 @@ function exportMachineToExcel($include_headers) {
 
     if (!$records) {
         jsAlertRedirect("No records found for export.", '../views/dashboard_machine.php');
+        exit;
     }
 
     $spreadsheet = new Spreadsheet();

--- a/app/includes/export_helpers/export_machine_output_helper.php
+++ b/app/includes/export_helpers/export_machine_output_helper.php
@@ -25,6 +25,7 @@ function exportMachineOutputToExcel($include_headers) {
 
     if (!$records) {
         jsAlertRedirect("No records found for export.", '../views/dashboard_applicator.php');
+        exit;
     }
 
     // Extract only the part_name values from custom MACHINE parts 

--- a/app/includes/export_helpers/export_machine_reset_helper.php
+++ b/app/includes/export_helpers/export_machine_reset_helper.php
@@ -28,6 +28,7 @@ function exportMachineResetsToExcel($include_headers, $date_range, $start_date =
 
     if (!$records) {
         jsAlertRedirect("No machine reset records found for export.", '../views/dashboard_machine.php');
+        exit;
     }
 
     $spreadsheet = new Spreadsheet();

--- a/app/includes/export_helpers/export_record_helper.php
+++ b/app/includes/export_helpers/export_record_helper.php
@@ -25,6 +25,7 @@ function exportRecordsToExcel($include_headers, $date_range, $start_date = null,
 
     if (!$records) {
         jsAlertRedirect("No records found for export.", '../views/record_output.php');
+        exit;
     }
 
     $spreadsheet = new Spreadsheet();

--- a/app/views/dashboard_applicator.php
+++ b/app/views/dashboard_applicator.php
@@ -59,7 +59,7 @@
         // CHECK FOR SEARCH RESULT AND REDIRECT IMMEDIATELY IF NOT FOUND
         if (empty($search_result)) {
             jsAlertRedirect("Applicator not found!", $_SERVER['PHP_SELF']);
-            exit();
+            exit;
         }
 
         $search_result = searchApplicatorByHpNo(trim($search_hp), $part_names_array);

--- a/app/views/dashboard_machine.php
+++ b/app/views/dashboard_machine.php
@@ -57,7 +57,7 @@
         // CHECK FOR SEARCH RESULT AND REDIRECT IMMEDIATELY IF NOT FOUND
         if (empty($search_results)) {
             jsAlertRedirect("Machine not found!", $_SERVER['PHP_SELF']);
-            exit();
+            exit;
         }
         
         // If searching, use search result instead of all records


### PR DESCRIPTION
## Summary
This PR improves safety and consistency across the codebase by ensuring that all `jsAlertRedirect()` calls are immediately followed by `exit`.  
Previously, some alert calls could allow the script to continue executing after the user was redirected, which could lead to unexpected behavior or security risks.  

## Key Changes
- Reviewed all controllers and scripts using `jsAlertRedirect()`.
- Added `exit;` immediately after each call to terminate script execution.
- No logic changes to existing validation or database operations.
- Ensures a clear separation between user feedback and backend processing.

## Benefits
- Prevents accidental execution of subsequent code after a redirect.
- Reduces potential security or consistency issues caused by continued script execution.
- Standardizes error-handling patterns across the entire codebase.

## Testing/validation
- Triggered various validation errors in applicator and machine dashboards → page shows alert and stops execution correctly.
- Confirmed that no further database or processing operations occur after the alert.
- Verified that redirects still function as expected in all tested flows.

## Implementation notes
- The `exit;` is placed immediately after the `jsAlertRedirect()` call, preserving the original alert behavior.
- No other code changes or logic refactors were performed.

## Risk/rollback
- Low risk; behavior of alerts remains unchanged.
- Rollback plan: remove the added `exit;` lines if any conflicts arise.

## Checklist
- [ / ] All `jsAlertRedirect()` calls now terminate with `exit;`.
- [ / ] Validated alert + redirect behavior across all controllers.
- [ / ] No unexpected script execution occurs after alerts.
- [ / ] No other code logic was modified.