### PR TITLE
fix(etl): adjust validation error row numbers to account for header lines

### DIFF
--- a/app/includes/etl/load.php
+++ b/app/includes/etl/load.php
@@ -85,40 +85,40 @@ function batchLoadData(array $rows): array {
             $outputVal = (int)($r['Output'] ?? 0);
 
             if ($app1No === '') {
-                $errors[] = "Row $line: Applicator1 is required.";
+                $errors[] = "Row " . ($line + 4) . ": Applicator1 is required.";
                 continue;
             }
             if (!isset($applicatorsMap[$app1No])) {
-                $errors[] = "Row $line: Applicator1 $app1No not found.";
+                $errors[] = "Row " . ($line + 4) . ": Applicator1 $app1No not found.";
                 continue;
             }
             if ($app2No !== '') {
                 if ($app2No === $app1No) {
-                    $errors[] = "Row $line: Duplicate applicator entry ($app1No).";
+                    $errors[] = "Row " . ($line + 4) . ": Duplicate applicator entry ($app1No).";
                     continue;
                 }
                 if (!isset($applicatorsMap[$app2No])) {
-                    $errors[] = "Row $line: Applicator2 $app2No not found.";
+                    $errors[] = "Row " . ($line + 4) . ": Applicator2 $app2No not found.";
                     continue;
                 }
             }
             if ($machineNo === '') {
-                $errors[] = "Row $line: Machine No is required.";
+                $errors[] = "Row " . ($line + 4) . ": Machine No is required.";
                 continue;
             }
             if (!isset($machinesMap[$machineNo])) {
-                $errors[] = "Row $line: Machine $machineNo not found.";
+                $errors[] = "Row " . ($line + 4) . ": Machine $machineNo not found.";
                 continue;
             }
 
             $shiftFormatted = formatShift($shiftRaw);
             if ($shiftFormatted === null) {
-                $errors[] = "Row $line: Invalid shift '$shiftRaw'.";
+                $errors[] = "Row " . ($line + 4) . ": Invalid shift '$shiftRaw'.";
                 continue;
             }
 
             if ($date === '' || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
-                $errors[] = "Row $line: Invalid or missing Date (expect YYYY-MM-DD).";
+                $errors[] = "Row " . ($line + 4) . ": Invalid or missing Date (expect YYYY-MM-DD).";
                 continue;
             }
 


### PR DESCRIPTION
## Summary
This PR fixes the row number calculation in ETL validation errors by adding an offset of +4.  
This ensures error messages reflect the actual row numbers in the uploaded file (accounting for 3 header lines and 0-based indexing).  

## Key Changes
- Updated all ETL validation error messages to use `($line + 4)` instead of `($line + 1)`.  
- Applies consistently across applicator, machine, shift, and date validations.  
- Example output:  
`Row 11: Applicator1 HP008testing not found.`

## Benefits
- Validation errors now align with the actual row numbers users see in their Excel files.  
- Eliminates confusion when reconciling errors with file contents.  
- Improves trust and usability of ETL error reporting.  

## Testing/Validation
- Uploaded sample files with intentional errors → verified reported row matches file line.  
- Checked multiple validation types (missing values, invalid formats, not found errors).  

## Risk/Rollback
- Low risk: only affects error message row calculation.  
- Rollback plan: revert line offset changes if unexpected row mismatches occur.  

## Checklist
- [x] Added +4 offset for row numbers in all ETL validation errors.  
- [x] Verified row numbers match Excel file rows.  
- [x] Confirmed no impact on ETL logic or database operations.  