### PR TITLE
feat(auth-ui): conditionally display login button based on session

### DIFF
--- a/app/views/home.php
+++ b/app/views/home.php
@@ -63,9 +63,11 @@ if (session_status() === PHP_SESSION_NONE) {
                         <button class="dashboard-btn" onclick="window.location.href='dashboard_machine.php'">
                             Machine Dashboard
                         </button>
-                        <button class="login-btn" onclick="window.location.href='login.php'">
-                            Log In
-                        </button>
+                        <?php if (empty($_SESSION['user_type'])): ?>
+                            <button class="login-btn" onclick="window.location.href='login.php'">
+                                Log In
+                            </button>
+                        <?php endif; ?>
                     </div>
                 </div>
 


### PR DESCRIPTION
Summary
This PR improves the authentication UI by only displaying the "Log In" button when the user is not logged in. The check is performed using the PHP session variable `user_type`.

Key Changes
Conditional Rendering
- Added a session check (`empty($_SESSION['user_type'])`) before rendering the login button.
- Prevents logged-in users from seeing the login option unnecessarily.

Benefits
- Provides a cleaner, more intuitive UI for authenticated users.
- Reduces confusion by only showing the login button when relevant.

Testing/Validation
- Logged in with a valid user → "Log In" button is hidden.
- Accessed the app without logging in → "Log In" button is displayed.

Risk/Rollback
Low risk: changes only affect the login button display logic.
Rollback plan: revert conditional rendering to always show the login button.

Checklist
- [x] Verified session check correctly hides/shows login button.
- [x] Confirmed no impact on other session-dependent features.