### PR TITLE
fix(search): remove onkeyup attribute causing debounce conflict

### DIFF
--- a/app/views/manage_user.php
+++ b/app/views/manage_user.php
@@ -69,7 +69,6 @@ requireAdmin();
                             class="search-input" 
                             id="userSearchInput"
                             placeholder="Search here..." 
-                            onkeyup="applyUserFilters(this.value)"
                             autocomplete="off"
                         >
                         <select 


### PR DESCRIPTION
## Summary
This PR fixes the search debounce functionality that wasn't working due to conflicting event handlers. The issue was caused by an inline `onkeyup` attribute that was triggering immediate searches, bypassing the debounced event listener.

## Key Changes
**Event Handler Cleanup**
- Removed inline `onkeyup="applyUserFilters(this.value)"` attribute from search input
- Ensured only the debounced event listener handles search functionality

## Benefits
- Reduces unnecessary API calls during fast typing
- Provides smoother search experience with proper debouncing
- Eliminates performance issues caused by excessive network requests
- Improves overall application responsiveness

## Testing/Validation
- Confirmed table no longer updates on every keystroke during fast typing
- Verified search properly waits 500ms after user stops typing before executing
- Console logs show debounce mechanism working correctly
- No duplicate network requests observed during rapid typing sessions

## Risk/Rollback
Low risk: changes only affect search input event handling logic.
Rollback plan: revert to previous event listener setup and restore inline onkeyup attribute.

## Checklist
- [x] Verified debounce correctly delays search execution
- [x] Confirmed no impact on role filter functionality
- [x] Tested with various typing speeds and patterns
- [x] Validated initial data loading still works properly