### PR TITLE
chore(export): improve header formatting for record exports

### DIFF
--- a/app/includes/export_helpers/export_record_helper.php
+++ b/app/includes/export_helpers/export_record_helper.php
@@ -48,6 +48,18 @@ function exportRecordsToExcel($include_headers, $date_range, $start_date = null,
         if ($include_headers && isset($chunk[0])) {
             $col = 1;
             foreach (array_keys($chunk[0]) as $header) {
+                // Replace 'hp1_no' with 'Applicator 1 (hp1_no)'
+                if ($header === 'hp1_no') {
+                    $header = 'Applicator 1 (hp1_no)';
+                }
+                // Replace 'hp2_no' with 'Applicator 2 (hp2_no)'
+                if ($header === 'hp2_no') {
+                    $header = 'Applicator 2 (hp2_no)';
+                }
+                // Replace 'control_no' with 'Machine Number (control_no)'
+                if ($header === 'control_no') {
+                    $header = 'Machine Number (control_no)';
+                }
                 $cell = \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($col) . $rowNum;
                 $sheet->setCellValue($cell, ucfirst(str_replace("_", " ", $header)));
                 $sheet->getStyle($cell)->getFont()->setBold(true);


### PR DESCRIPTION
## Summary
This PR updates the export functionality `records` by formatting certain column headers for clarity. Specific fields such as `hp1_no`, `hp2_no`, and `control_no` are replaced with more descriptive names in the exported Excel files.

## Key Changes
**Applicator Export**
- Replaced `hp1_no` with `Applicator 1 (hp1_no)`
- Replaced `hp2_no` with `Applicator 2 (hp2_no)`

**Machine Export**
- Replaced `control_no` with `Machine Number (control_no)`

## Benefits
- Column headers are more user-friendly and descriptive
- Improves clarity when reviewing exported Excel files
- Retains all previous export features including auto-sized columns and multiple sheet splitting

## Testing/Validation
- Exported records data
- Verified that formatted headers appear correctly in Excel
- Confirmed that multi-sheet exports and auto-sizing work as expected
- Ensured no data loss or corruption occurs

## Risk/Rollback
Low risk: changes only affect the display of column headers in Excel exports.
Rollback plan: revert the commit that updates the header formatting.

## Checklist
- [x] Record headers updated correctly
- [x] Export functionality works for both single and multi-sheet exports
- [x] Verified auto-size columns still function
- [x] Confirmed no data corruption occurs during export