### PR TITLE
enhance(edit-part-limits): change limit field step attribute to 10,000

### DIFF
--- a/app/views/applicator_edit_maximum_output.php
+++ b/app/views/applicator_edit_maximum_output.php
@@ -105,7 +105,7 @@
                                     placeholder="Enter maximum output limit..." 
                                     required
                                     min="0"
-                                    step="100000">
+                                    step="10000">
                             </div>
                         </div>
                     </div>

--- a/app/views/machine_edit_maximum_output.php
+++ b/app/views/machine_edit_maximum_output.php
@@ -103,7 +103,7 @@
                                     placeholder="Enter maximum output limit..." 
                                     required
                                     min="0"
-                                    step="100000">
+                                    step="10000">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
This PR enhances the **Edit Part Limits** for applicators and machines form by adjusting the step attribute of the limit input field.  
The step value is now set to **10,000**, allowing users to increment or decrement limits freely, in more practical intervals.  

## Key Changes
- Updated the `step` attribute of the limit field from its previous value to `10000` in the Edit Part Limits form.
