### PR TITLE
fix(read-joins): fix path resolution for model file used to fetch custom parts

### DIFF
--- a/app/models/read_joins/read_monitor_applicator_and_applicator.php
+++ b/app/models/read_joins/read_monitor_applicator_and_applicator.php
@@ -364,7 +364,7 @@ function getApplicatorOutputsForExport() {
     $records = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     // Get the custom part names of applicators
-    require_once __DIR__ . '/../models/read_custom_parts.php';
+    require_once __DIR__ . '/../../models/read_custom_parts.php';
     $custom_parts = getCustomParts("APPLICATOR");
 
     // Process custom parts output

--- a/app/models/read_joins/read_monitor_machine_and_machine.php
+++ b/app/models/read_joins/read_monitor_machine_and_machine.php
@@ -321,7 +321,7 @@ function getMachineOutputsForExport() {
     $records = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     // Get the custom part names of machines
-    require_once __DIR__ . '/../models/read_custom_parts.php';
+    require_once __DIR__ . '/../../models/read_custom_parts.php';
     $custom_parts = getCustomParts("MACHINE");
 
     // Process custom parts output


### PR DESCRIPTION
## Summary
This PR fixes an incorrect path resolution in the read-joins logic.  
The model file responsible for fetching custom parts was not being loaded properly due to an invalid relative path.  

## Key Changes
- Updated `require_once` path for `read_custom_parts.php` from:  
  `__DIR__ . '/../models/read_custom_parts.php'`  
  to:  
  `__DIR__ . '/../../models/read_custom_parts.php'`